### PR TITLE
Fix issue #27

### DIFF
--- a/app/coins/btc.js
+++ b/app/coins/btc.js
@@ -211,7 +211,7 @@ module.exports = {
 			"minfeerate": 0,
 			"mintxsize": 0,
 			"outs": 1,
-			"subsidy": 5000000000,
+			"subsidy": 50,
 			"swtotal_size": 0,
 			"swtotal_weight": 0,
 			"swtxs": 0,

--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -108,13 +108,14 @@ div.table-responsive
 
 						if (blockstatsByHeight)
 							td.data-cell.text-monospace.text-right
-								debugLog(blockstatsByHeight[block.height])
+								//- console.log(blockstatsByHeight[block.height])
 								if (blockstatsByHeight[block.height])
 									- var currencyValue = parseInt(new Decimal(blockstatsByHeight[block.height].total_out).plus(blockstatsByHeight[block.height].subsidy).plus(blockstatsByHeight[block.height].totalfee));
 									- var currencyValueDecimals = 0;
 									include ./value-display.pug
 
 								else
+									span 0
 
 						td.data-cell.text-monospace.text-right
 							- var currencyValue = new Decimal(block.totalFees).dividedBy(block.size).toDecimalPlaces(9);


### PR DESCRIPTION
Genesis block is special cased and getblockstats is not performed for it. The data for it is read from app/coinc/bch.js. Fact is that there the reward was represented in satoshis rather than BCH.