### PR TITLE
Activate "header by height" support via a config option

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -101,4 +101,8 @@
 
 # Show tools list in a sub-nav at top of screen
 # Default: true
-BTCEXP_UI_SHOW_TOOLS_SUBHEADER=true
+#BTCEXP_UI_SHOW_TOOLS_SUBHEADER=true
+
+# Does getblockheader support "height" as parameter?
+# Default: false
+#BTCEXP_HEADER_BY_HEIGHT_SUPPORT=false

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -490,7 +490,7 @@ function getBlocksByHeight(blockHeights) {
 
 function getBlockHeaderByHeight(blockHeight) {
 	return tryCacheThenRpcApi(blockCache, "getBlockHeaderByHeight-" + blockHeight, ONE_HR, function() {
-		return rpcApi.getBlockHeaderByHeightBU(blockHeight);
+		return rpcApi.getBlockHeaderByHeight(blockHeight);
 	});
 }
 

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -175,22 +175,22 @@ function getBlockHeaderByHash(blockhash) {
 }
 
 function getBlockHeaderByHeight(blockHeight) {
-	return new Promise(function(resolve, reject) {
-		getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]}).then(function(blockhash) {
-			getBlockHeaderByHash(blockhash).then(function(blockHeader) {
-				resolve(blockHeader);
+	if (!config.headerByHeightSupport) {
+		return new Promise(function(resolve, reject) {
+			getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]}).then(function(blockhash) {
+				getBlockHeaderByHash(blockhash).then(function(blockHeader) {
+					resolve(blockHeader);
 
+				}).catch(function(err) {
+					reject(err);
+				});
 			}).catch(function(err) {
 				reject(err);
 			});
-		}).catch(function(err) {
-			reject(err);
 		});
-	});
-}
-
-function getBlockHeaderByHeightBU(blockheight) {
-	return getRpcDataWithParams({method:"getblockheader", parameters:[blockheight]});
+	} else {
+		return getRpcDataWithParams({method:"getblockheader", parameters:[blockheight]});
+	}
 }
 
 function getBlockByHash(blockHash) {
@@ -506,7 +506,6 @@ module.exports = {
 	getBlockStatsByHeight: getBlockStatsByHeight,
 	getBlockHeaderByHash: getBlockHeaderByHash,
 	getBlockHeaderByHeight: getBlockHeaderByHeight,
-	getBlockHeaderByHeightBU: getBlockHeaderByHeightBU,
 
 	minRpcVersions: minRpcVersions
 };

--- a/app/config.js
+++ b/app/config.js
@@ -33,7 +33,7 @@ for (var i = 0; i < electrumXServerUriStrings.length; i++) {
   electrumXServers.push({protocol:uri.protocol.substring(0, uri.protocol.length - 1), host:uri.hostname, port:parseInt(uri.port)});
 }
 
-["BTCEXP_DEMO", "BTCEXP_PRIVACY_MODE", "BTCEXP_NO_INMEMORY_RPC_CACHE", "BTCEXP_UI_SHOW_RPC"].forEach(function(item) {
+["BTCEXP_DEMO", "BTCEXP_PRIVACY_MODE", "BTCEXP_NO_INMEMORY_RPC_CACHE", "BTCEXP_UI_SHOW_RPC", "BTCEXP_HEADER_BY_HEIGHT_SUPPORT"].forEach(function(item) {
   if (process.env[item] === undefined) {
     process.env[item] = "false";
   }
@@ -77,6 +77,7 @@ module.exports = {
   showRpc: (process.env.BTCEXP_UI_SHOW_RPC.toLowerCase() === "true"),
   queryExchangeRates: (process.env.BTCEXP_NO_RATES.toLowerCase() != "true"),
   noInmemoryRpcCache: (process.env.BTCEXP_NO_INMEMORY_RPC_CACHE.toLowerCase() == "true"),
+  headerByHeightSupport: (process.env.BTCEXP_HEADER_BY_HEIGHT_SUPPORT.toLowerCase() == "true"),
 
   rpcConcurrency: (process.env.BTCEXP_RPC_CONCURRENCY || 10),
 


### PR DESCRIPTION
Currently only BCH Unlimited support a block height as a parameter
to the getblockheader RPC call. In commit f69281c0d we assume that
all BCH clients support this which is not the case.

Since what we aim for this explorer is to work with all BCH clients
implementations, a new configuration parameter has been added to turn
this "header by height" functionality on/off (BTCEXP_HEADER_BY_HEIGHT_SUPPORT).