### PR TITLE
Add support for full nodes that support height as parameter to getblock

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -106,3 +106,7 @@
 # Does getblockheader support "height" as parameter?
 # Default: false
 #BTCEXP_HEADER_BY_HEIGHT_SUPPORT=false
+
+# Does getblock support "height" as parameter?
+# Default: false
+#BTCEXP_BLOCK_BY_HEIGHT_SUPPORT=false

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -165,18 +165,22 @@ function getChainTxStats(blockCount) {
 }
 
 function getBlockByHeight(blockHeight) {
-	return new Promise(function(resolve, reject) {
-		getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]}).then(function(blockhash) {
-			getBlockByHash(blockhash).then(function(block) {
-				resolve(block);
+	if (!config.blockByHeightSupport) {
+		return new Promise(function(resolve, reject) {
+			getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]}).then(function(blockhash) {
+				getBlockByHash(blockhash).then(function(block) {
+					resolve(block);
 
+				}).catch(function(err) {
+					reject(err);
+				});
 			}).catch(function(err) {
 				reject(err);
 			});
-		}).catch(function(err) {
-			reject(err);
 		});
-	});
+	} else {
+		return getRpcDataWithParams({method:"getblock", parameters:[blockHeight]});
+	}
 }
 
 function getBlockHeaderByHash(blockhash) {

--- a/app/config.js
+++ b/app/config.js
@@ -33,7 +33,7 @@ for (var i = 0; i < electrumXServerUriStrings.length; i++) {
   electrumXServers.push({protocol:uri.protocol.substring(0, uri.protocol.length - 1), host:uri.hostname, port:parseInt(uri.port)});
 }
 
-["BTCEXP_DEMO", "BTCEXP_PRIVACY_MODE", "BTCEXP_NO_INMEMORY_RPC_CACHE", "BTCEXP_UI_SHOW_RPC", "BTCEXP_HEADER_BY_HEIGHT_SUPPORT"].forEach(function(item) {
+["BTCEXP_DEMO", "BTCEXP_PRIVACY_MODE", "BTCEXP_NO_INMEMORY_RPC_CACHE", "BTCEXP_UI_SHOW_RPC", "BTCEXP_HEADER_BY_HEIGHT_SUPPORT", "BTCEXP_BLOCK_BY_HEIGHT_SUPPORT"].forEach(function(item) {
   if (process.env[item] === undefined) {
     process.env[item] = "false";
   }
@@ -79,6 +79,7 @@ module.exports = {
   queryExchangeRates: (process.env.BTCEXP_NO_RATES.toLowerCase() != "true"),
   noInmemoryRpcCache: (process.env.BTCEXP_NO_INMEMORY_RPC_CACHE.toLowerCase() == "true"),
   headerByHeightSupport: (process.env.BTCEXP_HEADER_BY_HEIGHT_SUPPORT.toLowerCase() == "true"),
+  blockByHeightSupport: (process.env.BTCEXP_BLOCK_BY_HEIGHT_SUPPORT.toLowerCase() == "true"),
 
   rpcConcurrency: (process.env.BTCEXP_RPC_CONCURRENCY || 10),
 


### PR DESCRIPTION
This functionality is off by default, you could turn it on by
setting BTCEXP_BLOCK_BY_HEIGHT_SUPPORT equal to true in the config
file.