### PR TITLE
Fix Redis cache with unknown miners

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -389,8 +389,9 @@ function getMinerFromCoinbaseTx(tx) {
 		return null;
 	}
 
-	var minerInfo = [];
+	var minerInfo = {};
 	if (global.miningPoolsConfigs) {
+		poolLoop:
 		for (var i = 0; i < global.miningPoolsConfigs.length; i++) {
 			var miningPoolsConfig = global.miningPoolsConfigs[i];
 
@@ -399,11 +400,8 @@ function getMinerFromCoinbaseTx(tx) {
 					if (tx.vout && tx.vout.length > 0 && tx.vout[0].scriptPubKey && tx.vout[0].scriptPubKey.addresses && tx.vout[0].scriptPubKey.addresses.length > 0) {
 						if (tx.vout[0].scriptPubKey.addresses[0] == payoutAddress) {
 							minerInfo = miningPoolsConfig.payout_addresses[payoutAddress];
-							minerInfo.coinbaseAscii = hex2ascii(tx.vin[0].coinbase);
-							minerInfo.noIFP=minerInfo.coinbaseAscii.search(/bchn/i);
 							minerInfo.identifiedBy = "payout address " + payoutAddress;
-
-							return minerInfo;
+							break poolLoop;
 						}
 					}
 				}
@@ -416,11 +414,7 @@ function getMinerFromCoinbaseTx(tx) {
 					if (coinbase.toLowerCase().indexOf(coinbase_tag) != -1) {
 						minerInfo = miningPoolsConfig.coinbase_tags[coinbaseTag];
 						minerInfo.identifiedBy = "coinbase tag '" + coinbaseTag + "'";
-						minerInfo.coinbaseAscii = hex2ascii(tx.vin[0].coinbase);
-						minerInfo.noIFP=minerInfo.coinbaseAscii.search(/bchn/i);
-
-
-						return minerInfo;
+						break poolLoop;
 					}
 				}
 			}
@@ -429,10 +423,7 @@ function getMinerFromCoinbaseTx(tx) {
 				if (blockHash == tx.blockhash) {
 					var minerInfo = miningPoolsConfig.block_hashes[blockHash];
 					minerInfo.identifiedBy = "known block hash '" + blockHash + "'";
-					minerInfo.coinbaseAscii = hex2ascii(tx.vin[0].coinbase);
-					minerInfo.noIFP=minerInfo.coinbaseAscii.search(/bchn/i);
-
-					return minerInfo;
+					break poolLoop;
 				}
 			}
 		}


### PR DESCRIPTION
The `getMinerFromCoinbaseTx` would return an array instead of an object, which caused Redis caching to fail. The Redis cache relies on the block object passing through `JSON.stringify` / `JSON.parse`, which can not handle named keys on an array.

This also reduces code duplication by breaking through the outer loop and determining `coinbaseAscii` and `noIFP` once at the end of the function.
