### PR TITLE
API: cache `getblock` requests with partial information

### DIFF
--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -168,102 +168,14 @@ function getBlockHash(blockHeight) {
 	return getRpcDataWithParams({method:"getblockhash", parameters:[blockHeight]});
 }
 
-function getBlockByHeight(blockHeight) {
-	if (!config.blockByHeightSupport) {
-		return new Promise(function(resolve, reject) {
-			getBlockHash(blockHeight).then(function(blockhash) {
-				getBlockByHash(blockhash).then(function(block) {
-					resolve(block);
-
-				}).catch(function(err) {
-					reject(err);
-				});
-			}).catch(function(err) {
-				reject(err);
-			});
-		});
-	} else {
-		return new Promise(function(resolve, reject) {
-			getRpcDataWithParams({method:"getblock", parameters:[blockHeight]}).then(function(block) {
-				getBlockByHeightReal(blockHeight).then(function(block) {
-					resolve(block);
-
-				}).catch(function(err) {
-					reject(err);
-				});
-			}).catch(function(err) {
-				reject(err);
-			});
-		});
-	}
+function getBlock(hash_or_height) {
+	return getRpcDataWithParams({method:"getblock", parameters:[hash_or_height]});
 }
 
-function getBlockByHash(blockHash) {
-	debugLog("getBlockByHash: %s", blockHash);
-
-	return new Promise(function(resolve, reject) {
-		getRpcDataWithParams({method:"getblock", parameters:[blockHash]}).then(function(block) {
-			getRawTransaction(block.tx[0]).then(function(tx) {
-				block.coinbaseTx = tx;
-				block.totalFees = utils.getBlockTotalFeesFromCoinbaseTxAndBlockHeight(tx, block.height);
-				block.subsidy = coinConfig.blockRewardFunction(block.height, global.activeBlockchain);
-				block.miner = utils.getMinerFromCoinbaseTx(tx);
-
-				resolve(block);
-
-			}).catch(function(err) {
-				reject(err);
-			});
-		}).catch(function(err) {
-			reject(err);
-		});
-	});
+function getBlockHeader(hash_or_height) {
+	return getRpcDataWithParams({method:"getblockheader", parameters:[hash_or_height]});
 }
 
-function getBlockByHeightReal(blockHeight) {
-	debugLog("getBlockByHeightReal: %s", blockHeight);
-
-	return new Promise(function(resolve, reject) {
-		getRpcDataWithParams({method:"getblock", parameters:[blockHeight]}).then(function(block) {
-			getRawTransaction(block.tx[0]).then(function(tx) {
-				block.coinbaseTx = tx;
-				block.totalFees = utils.getBlockTotalFeesFromCoinbaseTxAndBlockHeight(tx, block.height);
-				block.subsidy = coinConfig.blockRewardFunction(block.height, global.activeBlockchain);
-				block.miner = utils.getMinerFromCoinbaseTx(tx);
-
-				resolve(block);
-
-			}).catch(function(err) {
-				reject(err);
-			});
-		}).catch(function(err) {
-			reject(err);
-		});
-	});
-}
-
-function getBlockHeaderByHash(blockhash) {
-	return getRpcDataWithParams({method:"getblockheader", parameters:[blockhash]});
-}
-
-function getBlockHeaderByHeight(blockHeight) {
-	if (!config.headerByHeightSupport) {
-		return new Promise(function(resolve, reject) {
-			getBlockHash(blockHeight).then(function(blockhash) {
-				getBlockHeaderByHash(blockhash).then(function(blockHeader) {
-					resolve(blockHeader);
-
-				}).catch(function(err) {
-					reject(err);
-				});
-			}).catch(function(err) {
-				reject(err);
-			});
-		});
-	} else {
-		return getRpcDataWithParams({method:"getblockheader", parameters:[blockHeight]});
-	}
-}
 function getAddress(address) {
 	return getRpcDataWithParams({method:"validateaddress", parameters:[address]});
 }
@@ -537,8 +449,7 @@ module.exports = {
 	getMempoolTxids: getMempoolTxids,
 	getMiningInfo: getMiningInfo,
 	getBlockHash: getBlockHash,
-	getBlockByHeight: getBlockByHeight,
-	getBlockByHash: getBlockByHash,
+	getBlock: getBlock,
 	getRawTransaction: getRawTransaction,
 	getUtxo: getUtxo,
 	getMempoolTxDetails: getMempoolTxDetails,
@@ -554,8 +465,7 @@ module.exports = {
 	getNetworkHashrate: getNetworkHashrate,
 	getBlockStats: getBlockStats,
 	getBlockStatsByHeight: getBlockStatsByHeight,
-	getBlockHeaderByHash: getBlockHeaderByHash,
-	getBlockHeaderByHeight: getBlockHeaderByHeight,
+	getBlockHeader: getBlockHeader,
 	decodeScript: decodeScript,
 	decodeRawTransaction: decodeRawTransaction,
 

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -562,8 +562,8 @@ router.post("/search", function(req, res, next) {
 				return;
 			}
 
-			coreApi.getBlockByHash(query).then(function(blockByHash) {
-				if (blockByHash) {
+			coreApi.getBlockHeader(query).then(function(blockHeader) {
+				if (blockHeader) {
 					res.redirect("/block/" + query);
 
 					return;
@@ -588,8 +588,8 @@ router.post("/search", function(req, res, next) {
 			});
 
 		}).catch(function(err) {
-			coreApi.getBlockByHash(query).then(function(blockByHash) {
-				if (blockByHash) {
+			coreApi.getBlockHeader(query).then(function(blockHeader) {
+				if (blockHeader) {
 					res.redirect("/block/" + query);
 
 					return;
@@ -607,8 +607,8 @@ router.post("/search", function(req, res, next) {
 		});
 
 	} else if (!isNaN(query)) {
-		coreApi.getBlockByHeight(parseInt(query)).then(function(blockByHeight) {
-			if (blockByHeight) {
+		coreApi.getBlockHeaderByHeight(parseInt(query)).then(function(blockHeader) {
+			if (blockHeader) {
 				res.redirect("/block-height/" + query);
 
 				return;
@@ -666,12 +666,11 @@ router.get("/block-height/:blockHeight", function(req, res, next) {
 	res.locals.offset = offset;
 	res.locals.paginationBaseUrl = "/block-height/" + blockHeight;
 
-	coreApi.getBlockByHeight(blockHeight).then(function(result) {
-		res.locals.result.getblockbyheight = result;
+	rpcApi.getBlockHash(blockHeight).then(function(blockHash) {
 		var promises = [];
 
 		promises.push(new Promise(function(resolve, reject) {
-			coreApi.getBlockByHashWithTransactions(result.hash, limit, offset).then(function(result) {
+			coreApi.getBlockByHashWithTransactions(blockHash, limit, offset).then(function(result) {
 				res.locals.result.getblock = result.getblock;
 				res.locals.result.transactions = result.transactions;
 				res.locals.result.txInputsByTransaction = result.txInputsByTransaction;
@@ -686,7 +685,7 @@ router.get("/block-height/:blockHeight", function(req, res, next) {
 		}));
 
 		promises.push(new Promise(function(resolve, reject) {
-			coreApi.getBlockStats(result.hash).then(function(result) {
+			coreApi.getBlockStats(blockHash).then(function(result) {
 				res.locals.result.blockstats = result;
 
 				resolve();
@@ -806,7 +805,7 @@ router.get("/block-analysis/:blockHashOrHeight", function(req, res, next) {
 
 		res.locals.result = {};
 
-		coreApi.getBlockByHash(blockHash).then(function(block) {
+		coreApi.getBlock(blockHash, true).then(function(block) {
 			res.locals.result.getblock = block;
 
 			res.render("block-analysis");
@@ -822,7 +821,7 @@ router.get("/block-analysis/:blockHashOrHeight", function(req, res, next) {
 	};
 
 	if (!isNaN(blockHashOrHeight)) {
-		coreApi.getBlockByHeight(parseInt(blockHashOrHeight)).then(function(blockByHeight) {
+		coreApi.getBlockByHeight(parseInt(blockHashOrHeight), true).then(function(blockByHeight) {
 			goWithBlockHash(blockByHeight.hash);
 		});
 	} else {
@@ -1109,7 +1108,7 @@ router.get("/address/:address", function(req, res, next) {
 								if (coinbaseTxs.length > 0) {
 									// we need to query some blockHeights by hash for some coinbase txs
 									blockHeightsPromises.push(new Promise(function(resolve2, reject2) {
-										coreApi.getBlocksByHash(coinbaseTxBlockHashes).then(function(blocksByHashResult) {
+										coreApi.getBlocks(coinbaseTxBlockHashes, false).then(function(blocksByHashResult) {
 											for (var txid in blockHashesByTxid) {
 												if (blockHashesByTxid.hasOwnProperty(txid)) {
 													blockHeightsByTxid[txid] = blocksByHashResult[blockHashesByTxid[txid]].height;

--- a/views/block-analysis.pug
+++ b/views/block-analysis.pug
@@ -55,7 +55,7 @@ block content
 
 						div.row
 							div.summary-table-label Transactions
-							div.summary-table-content.text-monospace #{result.getblock.tx.length.toLocaleString()}
+							div.summary-table-content.text-monospace #{result.getblock.nTx.toLocaleString()}
 
 						div.row
 							div.summary-table-label Confirmations

--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -107,7 +107,7 @@ div.table-responsive
 								small.rounded.bg-success.text-white.px-1.py-1 NO IFP
 
 						
-						td.data-cell.text-monospace.text-right #{block.tx.length.toLocaleString()}
+						td.data-cell.text-monospace.text-right #{block.nTx.toLocaleString()}
 
 						if (blockstatsByHeight)
 							td.data-cell.text-monospace.text-right

--- a/views/mining-summary.pug
+++ b/views/mining-summary.pug
@@ -355,7 +355,7 @@ block endOfBody
 				}
 
 				summariesByMiner[miner.name].blockCount++;
-				summariesByMiner[miner.name].transactionCount += block.tx.length;
+				summariesByMiner[miner.name].transactionCount += block.nTx;
 				summariesByMiner[miner.name].totalSubsidiesCollected = summariesByMiner[miner.name].totalSubsidiesCollected.add(new Decimal(block.subsidy));
 				summariesByMiner[miner.name].totalFeesCollected = summariesByMiner[miner.name].totalFeesCollected.add(new Decimal(block.totalFees));
 				summariesByMiner[miner.name].blockSizeTotal += block.size;
@@ -367,7 +367,7 @@ block endOfBody
 
 				overallSummary.blockCount++;
 				if (block.miner.noIFP > 0) {overallSummary.blockCountNoIFP++;}
-				overallSummary.transactionCount += block.tx.length;
+				overallSummary.transactionCount += block.nTx;
 				overallSummary.totalSubsidiesCollected = overallSummary.totalSubsidiesCollected.add(new Decimal(block.subsidy));
 				overallSummary.totalFeesCollected = overallSummary.totalFeesCollected.add(new Decimal(block.totalFees));
 				overallSummary.blockSizeTotal += block.size;


### PR DESCRIPTION
First, this unifies all the `getBlock` and `getBlockHeader` functions to one common function in the RPC API. Handling height stuff is done in Core API.

The Core API adds a new parameter `full`, when it is set to `false`, the block will not be cached, when it is set to `true`, the block will be cached with one year expiry, but only containing the coinbase transaction. Also the miner info will not be cached to allow quickly updating the miner configs without needing to flush the cache.

The calls getting multiple blocks were simplified to use JS `.map()`.

All get `getBlock` calls for the search were changed to use `getBlockHash` instead, which saves a lot of time with big blocks.

The `/block-height` and `/block-analysis` page were changed to not fetch the same block twice.

Call sites where the TX data is not required were changed to not fetch the full block, benefitting from caching.

The block list relied on the TX data to show TX counts, this has been replaced with the blocks `nTx` counter. Not all nodes support the `nTx` property, so if it is undefined we compute it from `block.tx.length`.

Overall this give a significant speedup to many parts of the explorer.