### PR TITLE
Use dynamic chunk size when loading mempool

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -217,17 +217,23 @@ router.get("/mempool-summary", function(req, res, next) {
 		coreApi.getMempoolTxids().then(function(mempooltxids) {
 			var debugMaxCount = 0;
 
+			var inputChunkSize = 25;
+			if (mempooltxids.length > 1000)
+				inputChunkSize = 100;
+
 			if (debugMaxCount > 0) {
 				var debugtxids = [];
 				for (var i = 0; i < Math.min(debugMaxCount, mempooltxids.length); i++) {
 					debugtxids.push(mempooltxids[i]);
 				}
 
-				res.locals.mempooltxidChunks = utils.splitArrayIntoChunks(debugtxids, 25);
+				res.locals.mempooltxidChunks = utils.splitArrayIntoChunks(debugtxids, inputChunkSize);
 
 			} else {
-				res.locals.mempooltxidChunks = utils.splitArrayIntoChunks(mempooltxids, 25);
+				res.locals.mempooltxidChunks = utils.splitArrayIntoChunks(mempooltxids, inputChunkSize);
 			}
+
+			res.locals.inputChunkSize = inputChunkSize;
 
 
 			res.render("mempool-summary");

--- a/views/mempool-summary.pug
+++ b/views/mempool-summary.pug
@@ -88,9 +88,10 @@ block endOfBody
 	script.
 		var txidChunks = !{JSON.stringify(mempooltxidChunks)};
 		var satoshiPerByteBucketMaxima = !{JSON.stringify(satoshiPerByteBucketMaxima)};
+		var inputChunkSize = !{inputChunkSize};
 
 		$(document).ready(function() {
-			loadMempool(txidChunks, 25, txidChunks.length * 25);
+			loadMempool(txidChunks, inputChunkSize, txidChunks.length * inputChunkSize);
 		});
 
 		function loadMempool(txidChunks, chunkSize, count) {


### PR DESCRIPTION
This uses a larger chunk size when loading a lot of transactions. This could probably be better optimized for example by passing a index into a mempool snapshot, or just sending all TX, which is feasible. Chunk size can't be increased much further because of HTTP limitations, unless it is switched to HTTP PUSH.