### PR TITLE
Block list: Show the average fee in sats

### DIFF
--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -121,9 +121,13 @@ div.table-responsive
 									span 0
 
 						td.data-cell.text-monospace.text-right
-							- var currencyValue = new Decimal(block.totalFees).dividedBy(block.size).toDecimalPlaces(9);
-							- var currencyValueDecimals = 7;
+							- var currencyValue = new Decimal(block.totalFees).dividedBy(block.size);
+							- var currencyValueDecimals = 2;
+							- currencyFormatTypeOverride = "sat";
+							- currencyUnitSuffix = "/b"
 							include ./value-display.pug
+							- currencyFormatTypeOverride = null
+							- currencyUnitSuffix = null
 
 						td.data-cell.text-monospace.text-right
 							- var currencyValue = new Decimal(block.totalFees).toDecimalPlaces(9);

--- a/views/includes/value-display.pug
+++ b/views/includes/value-display.pug
@@ -1,10 +1,15 @@
-- var currencyFormatInfo = utils.getCurrencyFormatInfo(currencyFormatType);
+if (currencyFormatTypeOverride)
+	- var currencyFormatTypeInt = currencyFormatTypeOverride
+else
+	- var currencyFormatTypeInt = currencyFormatType;
+
+- var currencyFormatInfo = utils.getCurrencyFormatInfo(currencyFormatTypeInt);
 
 if (currencyValue > 0)
 	if (currencyValueDecimals)
-		- var parts = utils.formatCurrencyAmountWithForcedDecimalPlaces(currencyValue, currencyFormatType, currencyValueDecimals);
+		- var parts = utils.formatCurrencyAmountWithForcedDecimalPlaces(currencyValue, currencyFormatTypeInt, currencyValueDecimals);
 	else
-		- var parts = utils.formatCurrencyAmount(currencyValue, currencyFormatType);
+		- var parts = utils.formatCurrencyAmount(currencyValue, currencyFormatTypeInt);
 
 	//span #{JSON.stringify(currencyFormatInfo)}
 	span.text-monospace #{parts.val}#{(currencyValueDecimals && currencyFormatInfo.type == "native" && currencyFormatInfo.multiplier <= 1000) ? "…" : ""}
@@ -13,10 +18,10 @@ if (currencyValue > 0)
 
 	if (currencyFormatInfo.type == "native")
 		if (exchangeRates)
-			small.border-dotted.ml-1(data-toggle="tooltip", title=utils.formatExchangedCurrency(currencyValue, "usd")) #{parts.currencyUnit}
+			small.border-dotted.ml-1(data-toggle="tooltip", title=utils.formatExchangedCurrency(currencyValue, "usd")) #{parts.currencyUnit}#{currencyUnitSuffix}
 				
 		else
-			small.ml-1 #{parts.currencyUnit}
+			small.ml-1 #{parts.currencyUnit}#{currencyUnitSuffix}
 				
 	else if (currencyFormatInfo.type == "exchanged")
 		small.border-dotted.ml-1(data-toggle="tooltip", title=`${utils.formatCurrencyAmount(currencyValue, coinConfig.defaultCurrencyUnit.name).simpleVal} BCH`) #{parts.currencyUnit}


### PR DESCRIPTION
This overrides the users selected unit for the average fee display to always use satoshis. Adds a "/b" suffix to the unit.