### PR TITLE
Redis: Use MessagePack for a ~30% reduction in memory usage

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -987,6 +987,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-lite": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz",
+      "integrity": "sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g=="
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1360,6 +1365,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -1870,6 +1880,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+      "requires": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
     },
     "mv": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "semver": "^7.3.2",
     "serve-favicon": "^2.5.0",
     "simple-git": "^1.132.0",
-    "text-decoding": "^1.0.0"
+    "text-decoding": "^1.0.0",
+    "msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
     "less": "3.9.0",


### PR DESCRIPTION
`JSON` is not the best suited format to store in Redis given its large overhead. Redis supports `MessagePack` in its scripting language, so it can be used as a drop in replacement. A disadvantage is that the cached keys are not human readable anymore, but the JSON was hardly any better.

This adds a new dependency on the NPM `msgpack-lite` library. There are faster ones available but the performance is quite good already.

Note that for further reductions in memory usage a fast compression algorithm like `zstd` could be used.