### PR TITLE
Speed up block detail page, only fetch TX when needed

### DIFF
--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -84,6 +84,13 @@ router.get("/block-stats-by-height/:blockHeights", function(req, res, next) {
 	});
 });
 
+router.get("/txids-by-block/:blockHash", function(req, res, next) {
+	coreApi.getBlock(req.params.blockHash, true).then(function(block) {
+		res.json(block.tx);
+		utils.perfMeasure(req);
+	});
+});
+
 router.get("/mempool-txs/:txids", function(req, res, next) {
 	var txids = req.params.txids.split(",");
 

--- a/views/block.pug
+++ b/views/block.pug
@@ -15,3 +15,17 @@ block content
 		hr
 
 		include includes/block-content.pug
+
+block endOfBody
+	script.
+		$(document).ready(function() {
+			var blockHash = "!{result.getblock.hash}";
+			$('a[href="#tab-json-tx-ids"]').one('click', function (e) {
+				$.ajax({
+					url: `/api/txids-by-block/${blockHash}`
+				}).done(function(txids) {
+					$('#tab-json-tx-ids code').html(hljs.highlight('json', JSON.stringify(txids, null, 4)).value);
+					$('#tab-json-tx-ids-spinner').hide();
+				});
+			});
+		});

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -432,8 +432,7 @@ div.tab-content
 						include ./pagination.pug
 					
 	div.tab-pane(id="tab-json", role="tabpanel")
-		- var blockDetails = JSON.parse(JSON.stringify(result.getblock));
-		- blockDetails.tx = "See 'Transaction IDs'";
+		- result.getblock.tx = "See 'Transaction IDs'";
 
 		ul.nav.nav-pills.mb-3
 			li.nav-item
@@ -454,7 +453,7 @@ div.tab-content
 
 						div.highlight
 							pre
-								code.json.bg-light #{JSON.stringify(blockDetails, null, 4)}
+								code.json.bg-light #{JSON.stringify(result.getblock, null, 4)}
 
 			div.tab-pane(id="tab-json-tx-ids", role="tabpanel")
 				div.card.shadow-sm.mb-3
@@ -462,9 +461,12 @@ div.tab-content
 						h4.h6.mb-0 Transaction IDs
 						hr
 
+						div.spinner-border(id="tab-json-tx-ids-spinner", role="status")
+							span.sr-only Loading...
+
 						div.highlight
 							pre
-								code.json.bg-light #{JSON.stringify(result.getblock.tx, null, 4)}
+								code.json.bg-light
 
 			if (result.blockstats)
 				div.tab-pane(id="tab-json-blockstats", role="tabpanel")


### PR DESCRIPTION
Previously the block detail page would send *every* TX id in the block as a giant syntax highlighted JSON array, which would significantly increase the time required to build the response, the time to transfer the response, the time to render the site as well as the memory usage of the site. On 256MB blocks, the site would take ~1.4GB of memory.

This removes this list and instead AJAX loads it as plain JSON from an API endpoint. It uses highlight.js in the browser to do the syntax highlighting on the client side. With this change, big blocks load really fast and users can still get the TX list if they need it.