### PR TITLE
Fix display of unconfirmed transactions

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -940,15 +940,14 @@ router.get("/tx/:transactionId", function(req, res, next) {
 			}));
 		}
 
-		promises.push(new Promise(function(resolve, reject) {
-			coreApi.getBlockHeader(tx.blockhash).then(function(blockHeader) {
-				res.locals.result.blockHeader = blockHeader;
-				resolve()
-			}).catch(function(err) {
-				res.locals.pageErrors.push(utils.logError("089d7fyg04334", err));
-				reject(err);
-			});
-		}));
+		if (tx.blockhash !== undefined) {
+			promises.push(new Promise(function(resolve, reject) {
+				coreApi.getBlockHeader(tx.blockhash).then(function(blockHeader) {
+					res.locals.result.blockHeader = blockHeader;
+					resolve()
+				});
+			}));
+		}
 
 		Promise.all(promises).then(function() {
 			res.render("transaction");


### PR DESCRIPTION
Commit 9c92bd3b450b911255d4c6a3bd44a2f1e5eb90a8 broke the TX page for unconfirmed transactions. Error handling for `getblockheader` was added without considering that there are situations where it is expected to fail, like unconfirmed transactions.