### PR TITLE
Fix unconfirmed TX compatibility with ABC / BCHN

### DIFF
--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -210,6 +210,10 @@ function getRawTransaction(txid) {
 					return;
 				}
 
+				// ABC & BCHN do not set the confirmations property on unconfirmed TXs
+				if (result.confirmations === undefined)
+					result.confirmations = 0;
+
 				resolve(result);
 
 			}).catch(function(err) {


### PR DESCRIPTION
At least the ABC and BCHN node do not include the `confirmations` property in the `getrawtransaction` result. As a workaround, we set it to 0 when it is undefined.