### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+
+[*.js]
+charset = utf-8
+
+[*.pug]
+trim_trailing_whitespace = false


### PR DESCRIPTION
There seems to be an issue where trailing whitespace disappears in .pug template files. At least with editors supporting it, this can be prevented by including an .editorconfig file. The config is set to use LF for line endings, tab for indentation, use UTF-8 for JavaScript source and preserve trailing whitespace in pug files.