### PR TITLE
Add better unified coinbase display with potential signals

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -389,6 +389,8 @@ function logMemoryUsage() {
 	//debugLog("memoryUsage: heapUsed=" + mbUsed + ", heapTotal=" + mbTotal + ", ratio=" + parseInt(mbUsed / mbTotal * 100));
 }
 
+var possibleMinerSignalRE = /\/(.*)\//;
+
 function getMinerFromCoinbaseTx(tx) {
 	if (tx == null || tx.vin == null || tx.vin.length == 0) {
 		return null;
@@ -397,6 +399,10 @@ function getMinerFromCoinbaseTx(tx) {
 	var minerInfo = {
 		coinbaseStr: hex2string(tx.vin[0].coinbase)
 	};
+
+	var possibleSignal = minerInfo.coinbaseStr.match(possibleMinerSignalRE);
+	if (possibleSignal)
+		minerInfo.possibleSignal = possibleSignal[1];
 
 	if (global.miningPoolsConfigs) {
 		poolLoop:

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -175,10 +175,8 @@ div.tab-content
 								div.row
 									div.summary-split-table-label Miner
 									div.summary-split-table-content.text-monospace.mb-0
-										if (result.getblock.miner.identifiedBy)
-											small.data-tag.bg-primary(data-toggle="tooltip", title=("Identified by: " + result.getblock.miner.identifiedBy)) #{result.getblock.miner.name}
-										else
-											small.data-tag.bg-primary(data-toggle="tooltip", title=(result.getblock.miner.coinbaseStr)) ?
+										- var block = result.getblock
+										include coinbase-display.pug
 
 							div.row
 								div(class=sumTableLabelClass) Confirmations

--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -98,11 +98,7 @@ div.table-responsive
 									span.font-weight-light.text-muted -
 						
 						td.data-cell.text-monospace.text-right
-							if (block.miner && block.miner.name)
-								small.rounded.bg-primary.text-white.px-2.py-1(data-toggle="tooltip", title=(block.miner.coinbaseStr)) #{utils.ellipsize(block.miner.name, 10)}
-							else
-								small.rounded.bg-secondary.text-white.px-2.py-1(data-toggle="tooltip", title=(block.miner.coinbaseStr)) ?
-
+							include coinbase-display.pug
 						
 						td.data-cell.text-monospace.text-right #{block.nTx.toLocaleString()}
 

--- a/views/includes/coinbase-display.pug
+++ b/views/includes/coinbase-display.pug
@@ -1,0 +1,6 @@
+if (block.miner && block.miner.name)
+    small.rounded.bg-primary.text-white.px-2.py-1(data-toggle="tooltip", title=(("Identified by: " + block.miner.identifiedBy + " in " + block.miner.coinbaseStr))) #{utils.ellipsize(block.miner.name, 25)}
+else if (block.miner && block.miner.possibleSignal)
+    small.rounded.bg-info.text-white.px-2.py-1(data-toggle="tooltip", title=(block.miner.coinbaseStr)) #{utils.ellipsize(block.miner.possibleSignal, 25)}
+else
+    small.rounded.bg-secondary.text-white.px-2.py-1(data-toggle="tooltip", title=(block.miner.coinbaseStr)) ?


### PR DESCRIPTION
Moves the code from `block-content.pug` and `blocks-list.pug` into an includable file that needs to have the `block` variable set as an input.

Unifies how the coinbase string is displayed in the blocks list and block details page.

This also displays suspected signals in a 3rd color. A suspected signal is any string between two / characters with greedy matching.