### PR TITLE
Remove getBlockStatsByHeight

### DIFF
--- a/app.js
+++ b/app.js
@@ -314,7 +314,7 @@ function refreshNetworkVolumes() {
 
 		for (var i = 0; i < (blocksPerDay * 1); i++) {
 			if (result.blocks - i >= 0) {
-				promises.push(coreApi.getBlockStatsByHeight(result.blocks - i));
+				promises.push(coreApi.getBlockStats(result.blocks - i));
 			}
 		}
 

--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -253,9 +253,9 @@ function getNetworkHashrate(blockCount) {
 	});
 }
 
-function getBlockStats(hash) {
-	return tryCacheThenRpcApi(miscCache, "getBlockStats-" + hash, ONE_YR, function() {
-		return rpcApi.getBlockStats(hash);
+function getBlockStats(hash_or_height) {
+	return tryCacheThenRpcApi(miscCache, "getBlockStats-" + hash_or_height, ONE_YR, function() {
+		return rpcApi.getBlockStats(hash_or_height);
 	});
 }
 
@@ -268,20 +268,6 @@ function decodeScript(hex) {
 function decodeRawTransaction(hex) {
 	return tryCacheThenRpcApi(miscCache, "decodeRawTransaction-" + hex, 1000 * 60 * 1000, function() {
 		return rpcApi.decodeRawTransaction(hex);
-	});
-}
-
-function getBlockStatsByHeight(height) {
-	return new Promise(function(resolve, reject) {
-		rpcApi.getBlockHash(height).then(function(blockhash) {
-			getBlockStats(blockhash).then(function(blockstats) {
-				resolve(blockstats);
-			}).catch(function(err) {
-				reject(err);
-			});
-		}).catch(function(err) {
-			reject(err);
-		});
 	});
 }
 
@@ -612,7 +598,7 @@ function getBlockHeadersByHeight(blockHeights) {
 
 function getBlocksStatsByHeight(blockHeights) {
 	return new Promise(function(resolve, reject) {
-		Promise.all(blockHeights.map(h => getBlockStatsByHeight(h))).then(function(results) {
+		Promise.all(blockHeights.map(h => getBlockStats(h))).then(function(results) {
 			resolve(results);
 		}).catch(function(err) {
 			reject(err);
@@ -1074,7 +1060,6 @@ module.exports = {
 	getUtxoSetSummary: getUtxoSetSummary,
 	getNetworkHashrate: getNetworkHashrate,
 	getBlockStats: getBlockStats,
-	getBlockStatsByHeight: getBlockStatsByHeight,
 	getBlocksStatsByHeight: getBlocksStatsByHeight,
 	buildBlockAnalysisData: buildBlockAnalysisData,
 	getBlockHeader: getBlockHeader,

--- a/app/api/rpcApi.js
+++ b/app/api/rpcApi.js
@@ -70,31 +70,15 @@ function getNetworkHashrate(blockCount=144) {
 	return getRpcDataWithParams({method:"getnetworkhashps", parameters:[blockCount]});
 }
 
-function getBlockStats(hash) {
+function getBlockStats(hash_or_height) {
 	if (semver.gte(global.btcNodeSemver, minRpcVersions.getblockstats)) {
-		if (hash == coinConfig.genesisBlockHashesByNetwork[global.activeBlockchain] && coinConfig.genesisBlockStatsByNetwork[global.activeBlockchain]) {
+		if ((hash_or_height == coinConfig.genesisBlockHashesByNetwork[global.activeBlockchain] || hash_or_height == 0) && coinConfig.genesisBlockStatsByNetwork[global.activeBlockchain]) {
 			return new Promise(function(resolve, reject) {
 				resolve(coinConfig.genesisBlockStatsByNetwork[global.activeBlockchain]);
 			});
 
 		} else {
-			return getRpcDataWithParams({method:"getblockstats", parameters:[hash]});
-		}
-	} else {
-		// unsupported
-		return unsupportedPromise(minRpcVersions.getblockstats);
-	}
-}
-
-function getBlockStatsByHeight(height) {
-	if (semver.gte(global.btcNodeSemver, minRpcVersions.getblockstats)) {
-		if (height == 0 && coinConfig.genesisBlockStatsByNetwork[global.activeBlockchain]) {
-			return new Promise(function(resolve, reject) {
-				resolve(coinConfig.genesisBlockStatsByNetwork[global.activeBlockchain]);
-			});
-
-		} else {
-			return getRpcDataWithParams({method:"getblockstats", parameters:[height]});
+			return getRpcDataWithParams({method:"getblockstats", parameters:[hash_or_height]});
 		}
 	} else {
 		// unsupported
@@ -468,7 +452,6 @@ module.exports = {
 	getUtxoSetSummary: getUtxoSetSummary,
 	getNetworkHashrate: getNetworkHashrate,
 	getBlockStats: getBlockStats,
-	getBlockStatsByHeight: getBlockStatsByHeight,
 	getBlockHeader: getBlockHeader,
 	decodeScript: decodeScript,
 	decodeRawTransaction: decodeRawTransaction,


### PR DESCRIPTION
The 2 nodes currently supported (BCH Unlimited and BCHN)
`getblockstats` RPC call works both by block height or
block hash.

Hence removing the useless `getBlockStatsByHeight` wrap
around `getBlockStats`.