### PR TITLE
Fix a bunch of satoshi conversions

### DIFF
--- a/views/block-stats.pug
+++ b/views/block-stats.pug
@@ -294,6 +294,7 @@ block endOfBody
 			});
 		}
 
+		var satsMultiplier = !{coinConfig.baseCurrencyUnit.multiplier};
 		function summarizeData(results) {
 			var summary = {};
 
@@ -332,16 +333,16 @@ block endOfBody
 			summary.utxo_increase = [];
 
 			for (var i = results.length - 1; i >= 0; i--) {
-				summary.avgfeerate.push({x:results[i].height, y:results[i].avgfeerate});
-				summary.medianfeerate.push({x:results[i].height, y:results[i].feerate_percentiles[2]});
-				summary.minfeerate.push({x:results[i].height, y:results[i].minfeerate});
+				summary.avgfeerate.push({x:results[i].height, y:results[i].avgfeerate * satsMultiplier});
+				summary.medianfeerate.push({x:results[i].height, y:results[i].feerate_percentiles[2] * satsMultiplier});
+				summary.minfeerate.push({x:results[i].height, y:results[i].minfeerate * satsMultiplier});
 				
-				summary.maxfeerate.push({x:results[i].height, y:results[i].maxfeerate});
+				summary.maxfeerate.push({x:results[i].height, y:results[i].maxfeerate * satsMultiplier});
 
-				summary.totalfee.push({x:results[i].height, y:new Decimal(results[i].totalfee).dividedBy(100000000)});
+				summary.totalfee.push({x:results[i].height, y:new Decimal(results[i].totalfee)});
 				
-				summary.minfee.push({x:results[i].height, y:results[i].minfee});
-				summary.maxfee.push({x:results[i].height, y:results[i].maxfee});
+				summary.minfee.push({x:results[i].height, y:results[i].minfee * satsMultiplier});
+				summary.maxfee.push({x:results[i].height, y:results[i].maxfee * satsMultiplier});
 				
 				summary.inputs.push({x:results[i].height, y:results[i].ins});
 				summary.outputs.push({x:results[i].height, y:results[i].outs});
@@ -352,7 +353,7 @@ block endOfBody
 
 				summary.maxtxsize.push({x:results[i].height, y:results[i].maxtxsize});
 				
-				summary.totaloutput.push({x:results[i].height, y:new Decimal(results[i].total_out).dividedBy(100000000)});
+				summary.totaloutput.push({x:results[i].height, y:new Decimal(results[i].total_out)});
 				
 				summary.size.push({x:results[i].height, y:results[i].total_size});
 				

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -23,6 +23,7 @@ ul.nav.nav-tabs.mb-3
 		a.nav-link(data-toggle="tab", href="#tab-json", role="tab") JSON
 
 - var txCount = result.getblock.tx.length;
+- var satsMultiplier = coinConfig.baseCurrencyUnit.multiplier;
 
 div.tab-content
 	div.tab-pane.active(id="tab-details", role="tabpanel")
@@ -80,9 +81,8 @@ div.tab-content
 										span.border-dotted(title="Total value of all transaction outputs", data-toggle="tooltip")
 											span Total Output
 									div.text-monospace(class=sumTableValueClass)
-										if (result.blockstats.total_out)
-											- var currencyValue = new Decimal(result.blockstats.total_out).plus(new Decimal(result.blockstats.totalfee)).plus(new Decimal(result.blockstats.subsidy));
-											- currencyValue = currencyValue.dividedBy(coinConfig.baseCurrencyUnit.multiplier);
+										if (result.blockstats.total_out !== undefined)
+											- var currencyValue = new Decimal(result.blockstats.total_out).plus(result.blockstats.totalfee).plus(result.blockstats.subsidy);
 											include ./value-display.pug
 										else
 											span 0
@@ -218,13 +218,14 @@ div.tab-content
 												- var currencyValue = new Decimal(result.blockstats.avgfeerate);
 											else
 												- var currencyValue = new Decimal(result.getblock.totalFees).dividedBy(result.getblock.size);
-											include ./value-display.pug
+											span #{(currencyValue * satsMultiplier).toLocaleString()}
+											small.ml-1 #{coinConfig.baseCurrencyUnit.name}/B
 
 									if (result.blockstats)
 										div.row
 											div.summary-split-table-label Rate Percentiles
 												br
-												small.font-weight-normal (sat/B)
+												small.font-weight-normal (#{coinConfig.baseCurrencyUnit.name}/B)
 											div.summary-split-table-content.text-monospace
 												div.clearfix
 													each item, itemIndex in [10, 25, 50, 75, 90]
@@ -245,23 +246,23 @@ div.tab-content
 												small (min, avg, max)
 												
 											div.summary-split-table-content.text-monospace
-												if (result.blockstats.minfeerate)
-													span #{(result.blockstats.minfeerate * 100000000).toLocaleString()}
-													small.ml-1 sat/B
+												if (result.blockstats.minfeerate !== undefined)
+													span #{(result.blockstats.minfeerate * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}/B
 												else
 													span ?
 
 												br
 
-												if (result.blockstats.avgfeerate)
-													span #{(result.blockstats.avgfeerate * 10000000).toLocaleString()}
-													small.ml-1 sat/B
+												if (result.blockstats.avgfeerate !== undefined)
+													span #{(result.blockstats.avgfeerate * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}/B
 
 												br
 
-												if (result.blockstats.maxfeerate)
-													span #{(result.blockstats.maxfeerate * 10000000).toLocaleString()}
-													small.ml-1 sat/B
+												if (result.blockstats.maxfeerate !== undefined)
+													span #{(result.blockstats.maxfeerate * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}/B
 												else
 													span ?
 
@@ -272,25 +273,25 @@ div.tab-content
 												br
 												small (min, avg, max)
 											div.summary-split-table-content.text-monospace
-												if (result.blockstats.minfee)
-													- var currencyValue = new Decimal(result.blockstats.minfee).dividedBy(coinConfig.baseCurrencyUnit.multiplier);
-													include ./value-display.pug
+												if (result.blockstats.minfee !== undefined)
+													span #{(result.blockstats.minfee * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}
 												else
 													span 0
 
 												br
 
-												if (result.blockstats.avgfee)
-													- var currencyValue = new Decimal(result.blockstats.avgfee).dividedBy(coinConfig.baseCurrencyUnit.multiplier);
-													include ./value-display.pug
+												if (result.blockstats.avgfee !== undefined)
+													span #{(result.blockstats.avgfee * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}
 												else
 													span 0
 												
 												br
 
-												if (result.blockstats.maxfee)
-													- var currencyValue = new Decimal(result.blockstats.maxfee);
-													include ./value-display.pug
+												if (result.blockstats.maxfee !== undefined)
+													span #{(result.blockstats.maxfee * satsMultiplier).toLocaleString()}
+													small.ml-1 #{coinConfig.baseCurrencyUnit.name}
 												else
 													span 0
 

--- a/views/mempool-summary.pug
+++ b/views/mempool-summary.pug
@@ -480,12 +480,13 @@ block endOfBody
 				"sizeBucketLabels":sizeBucketLabels
 			};
 
+			var satsMultiplier = !{coinConfig.baseCurrencyUnit.multiplier};
 			for (var x = 0; x < rawdata.length; x++) {
 				var txMempoolInfo = rawdata[x].entry;
 				var fee = txMempoolInfo.modifiedfee;
 				var size = txMempoolInfo.vsize ? txMempoolInfo.vsize : txMempoolInfo.size;
 				var feePerByte = txMempoolInfo.modifiedfee / size;
-				var satoshiPerByte = feePerByte * 100000000; // TODO: magic number - replace with coinConfig.baseCurrencyUnit.multiplier
+				var satoshiPerByte = feePerByte * satsMultiplier;
 				var age = Date.now() / 1000 - txMempoolInfo.time;
 
 				var addedToBucket = false;

--- a/views/transaction.pug
+++ b/views/transaction.pug
@@ -191,7 +191,7 @@ block content
 								div.row
 									div.summary-table-label Fee Rate
 									div.summary-table-content.text-monospace
-										span.text-muted (#{utils.addThousandsSeparators(new DecimalRounded(totalInputValue).minus(totalOutputValue).dividedBy(result.getrawtransaction.size).times(100000000))}
+										span.text-muted (#{utils.addThousandsSeparators(new DecimalRounded(totalInputValue).minus(totalOutputValue).dividedBy(result.getrawtransaction.size).times(coinConfig.baseCurrencyUnit.multiplier))}
 											small sat/B)
 
 							- var daysDestroyed = new Decimal(0);


### PR DESCRIPTION
Some places were not using the `baseCurrencyUnit.multiplier`, some were even using the wrong multiplier. Other places assumed `getblockstats` returns satoshis like it does on core. This also changes the block fee value display to be in the base currency unit.