### PR TITLE
Fix ABC block stats view

### DIFF
--- a/views/block-stats.pug
+++ b/views/block-stats.pug
@@ -330,7 +330,7 @@ block endOfBody
 
 			for (var i = results.length - 1; i >= 0; i--) {
 				summary.avgfeerate.push({x:results[i].height, y:results[i].avgfeerate * satsMultiplier});
-				summary.medianfeerate.push({x:results[i].height, y:results[i].feerate_percentiles[2] * satsMultiplier});
+				summary.medianfeerate.push({x:results[i].height, y:(results[i].feerate_percentiles[2] || results[i].medianfeerate) * satsMultiplier});
 				summary.minfeerate.push({x:results[i].height, y:results[i].minfeerate * satsMultiplier});
 				
 				summary.maxfeerate.push({x:results[i].height, y:results[i].maxfeerate * satsMultiplier});


### PR DESCRIPTION
ABC lacks `feerate_percentiles` so we use `medianfeerate` instead.