### PR TITLE
Charts: Use index mode

### DIFF
--- a/views/block-analysis.pug
+++ b/views/block-analysis.pug
@@ -463,6 +463,10 @@ block endOfBody
 								labelString: yLabelStr
 							}
 						}]
+					},
+					tooltips: {
+						mode: 'index',
+						intersect: false
 					}
 				}
 			});
@@ -495,6 +499,10 @@ block endOfBody
 								beginAtZero:true
 							}
 						}]
+					},
+					tooltips: {
+						mode: 'index',
+						intersect: false
 					}
 				}
 			});

--- a/views/block-stats.pug
+++ b/views/block-stats.pug
@@ -417,6 +417,10 @@ block endOfBody
 									labelString: yunit
 								}
 							}]
+						},
+						tooltips: {
+							mode: 'index',
+							intersect: false
 						}
 					}
 				});

--- a/views/difficulty-history.pug
+++ b/views/difficulty-history.pug
@@ -92,6 +92,10 @@ block endOfBody
 								labelString: yLabelStr
 							}
 						}]
+					},
+					tooltips: {
+						mode: 'index',
+						intersect: false
 					}
 				}
 			};

--- a/views/includes/line-graph.pug
+++ b/views/includes/line-graph.pug
@@ -35,6 +35,10 @@ script.
 			legend: {
 				display: false
 			},
+			tooltips: {
+				mode: 'index',
+				intersect: false
+			},
 			scales: {
 				xAxes: [{
 					type: 'linear',

--- a/views/mempool-summary.pug
+++ b/views/mempool-summary.pug
@@ -178,6 +178,10 @@ block endOfBody
 									beginAtZero:true
 								}
 							}]
+						},
+						tooltips: {
+							mode: 'index',
+							intersect: false
 						}
 					}
 				});
@@ -203,6 +207,10 @@ block endOfBody
 									beginAtZero:true
 								}
 							}]
+						},
+						tooltips: {
+							mode: 'index',
+							intersect: false
 						}
 					}
 				});
@@ -228,6 +236,10 @@ block endOfBody
 									beginAtZero:true
 								}
 							}]
+						},
+						tooltips: {
+							mode: 'index',
+							intersect: false
 						}
 					}
 				});


### PR DESCRIPTION
Index mode with intersect disabled makes it so that points do not have to be hovered exactly, but instead the next point on the X axis is chosen, ignoring the Y axis.

See https://www.chartjs.org/docs/latest/general/interactions/modes.html#interaction-modes