### PR TITLE
Block lists: Use new common `getBlockList` function

### DIFF
--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -38,6 +38,25 @@ router.get("/mempoolinfo", function(req, res, next) {
 	});
 });
 
+router.get("/blocks", function(req, res, next) {
+	var args = {}
+	if (req.query.limit)
+		args.limit = parseInt(req.query.limit);
+	if (req.query.offset)
+		args.offset = parseInt(req.query.offset);
+	if (req.query.sort)
+		args.sort = req.query.sort;
+
+	coreApi.getBlockList(args).then(function(data) {
+		res.json(data);
+
+		utils.perfMeasure(req);
+	}).catch(function(err) {
+		res.json({success:false, error:err});
+
+		next();
+	});
+});
 
 router.get("/blocks-by-height/:blockHeights", function(req, res, next) {
 	var blockHeightStrs = req.params.blockHeights.split(",");

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -1117,10 +1117,12 @@ router.get("/address/:address", function(req, res, next) {
 								if (coinbaseTxs.length > 0) {
 									// we need to query some blockHeights by hash for some coinbase txs
 									blockHeightsPromises.push(new Promise(function(resolve2, reject2) {
-										coreApi.getBlocks(coinbaseTxBlockHashes, false).then(function(blocksByHashResult) {
+										coreApi.getBlocks(coinbaseTxBlockHashes, false).then(function(blocks) {
+											var blocksByHash = {};
+											blocks.forEach(b => blocksByHash[b.hash] = b);
 											for (var txid in blockHashesByTxid) {
 												if (blockHashesByTxid.hasOwnProperty(txid)) {
-													blockHeightsByTxid[txid] = blocksByHashResult[blockHashesByTxid[txid]].height;
+													blockHeightsByTxid[txid] = blocksByHash[blockHashesByTxid[txid]].height;
 												}
 											}
 

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -113,20 +113,6 @@ router.get("/", function(req, res, next) {
 
 			var rawSmartFeeEstimates = promiseResults[2];
 
-			var smartFeeEstimates = {};
-
-			//for (var i = 0; i < feeConfTargets.length; i++) {
-			//	var rawSmartFeeEstimate = rawSmartFeeEstimates[i];
-			//	if (rawSmartFeeEstimate.errors) {
-			//		smartFeeEstimates[feeConfTargets[i]] = "?";
-			//	} else {
-			//		smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
-			//	}
-			//}
-
-			res.locals.smartFeeEstimates = smartFeeEstimates;
-
-
 			res.locals.hashrate1d = promiseResults[3];
 			res.locals.hashrate7d = promiseResults[4];
 

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -52,13 +52,8 @@ router.get("/", function(req, res, next) {
 	// don't need timestamp on homepage "blocks-list", this flag disables
 	//res.locals.hideTimestampColumn = true;
 
-	// variables used by blocks-list.pug
-	res.locals.offset = 0;
-	res.locals.sort = "desc";
-
 	var feeConfTargets = [1, 6, 144, 1008];
 	res.locals.feeConfTargets = feeConfTargets;
-
 
 	var promises = [];
 
@@ -71,43 +66,30 @@ router.get("/", function(req, res, next) {
 	promises.push(coreApi.getNetworkHashrate(144));
 	promises.push(coreApi.getNetworkHashrate(1008));
 
-	coreApi.getBlockchainInfo().then(function(getblockchaininfo) {
-		res.locals.getblockchaininfo = getblockchaininfo;
+	coreApi.getBlockList({ limit: config.site.homepage.recentBlocksCount }).then(function(data) {
+		Object.assign(res.locals, data);
 
-		res.locals.difficultyPeriod = parseInt(Math.floor(getblockchaininfo.blocks / coinConfig.difficultyAdjustmentBlockCount));
-
-		var blockHeights = [];
-		if (getblockchaininfo.blocks) {
-			// +1 to page size here so we have the next block to calculate T.T.M.
-			for (var i = 0; i < (config.site.homepage.recentBlocksCount + 1); i++) {
-				blockHeights.push(getblockchaininfo.blocks - i);
-			}
-		} else if (global.activeBlockchain == "regtest") {
-			// hack: default regtest node returns getblockchaininfo.blocks=0, despite having a genesis block
-			// hack this to display the genesis block
-			blockHeights.push(0);
-		}
+		res.locals.difficultyPeriod = parseInt(Math.floor(data.blockChainInfo.blocks / coinConfig.difficultyAdjustmentBlockCount));
 
 		// promiseResults[5]
-		promises.push(coreApi.getBlocksStatsByHeight(blockHeights));
+		promises.push(0);
 
 		// promiseResults[6]
 		promises.push(new Promise(function(resolve, reject) {
 			coreApi.getBlockHeaderByHeight(coinConfig.difficultyAdjustmentBlockCount * res.locals.difficultyPeriod).then(function(difficultyPeriodFirstBlockHeader) {
-
 				resolve(difficultyPeriodFirstBlockHeader);
 			});
 		}));
 
 
-		if (getblockchaininfo.chain !== 'regtest') {
+		if (data.blockChainInfo.chain !== 'regtest') {
 			var targetBlocksPerDay = 24 * 60 * 60 / global.coinConfig.targetBlockTimeSeconds;
 
 			// promiseResults[7] (if not regtest)
 			promises.push(coreApi.getTxCountStats(targetBlocksPerDay / 4, -targetBlocksPerDay, "latest"));
 
 			var chainTxStatsIntervals = [ targetBlocksPerDay, targetBlocksPerDay * 7, targetBlocksPerDay * 30, targetBlocksPerDay * 365 ]
-				.filter(numBlocks => numBlocks <= getblockchaininfo.blocks);
+				.filter(numBlocks => numBlocks <= data.blockChainInfo.blocks);
 
 			res.locals.chainTxStatsLabels = [ "24 hours", "1 week", "1 month", "1 year" ]
 				.slice(0, chainTxStatsIntervals.length)
@@ -119,64 +101,50 @@ router.get("/", function(req, res, next) {
 			}
 		}
 
-		if (getblockchaininfo.chain !== 'regtest') {
-			promises.push(coreApi.getChainTxStats(getblockchaininfo.blocks - 1));
+		if (data.blockChainInfo.chain !== 'regtest') {
+			promises.push(coreApi.getChainTxStats(data.blockChainInfo.blocks - 1));
 		}
 
-		coreApi.getBlocksByHeight(blockHeights).then(function(latestBlocks) {
-			res.locals.latestBlocks = latestBlocks;
-			res.locals.blocksUntilDifficultyAdjustment = ((res.locals.difficultyPeriod + 1) * coinConfig.difficultyAdjustmentBlockCount) - latestBlocks[0].height;
+		res.locals.blocksUntilDifficultyAdjustment = ((res.locals.difficultyPeriod + 1) * coinConfig.difficultyAdjustmentBlockCount) - data.blockList[0].height;
+
+		Promise.all(promises).then(function(promiseResults) {
+			res.locals.mempoolInfo = promiseResults[0];
+			res.locals.miningInfo = promiseResults[1];
+
+			var rawSmartFeeEstimates = promiseResults[2];
+
+			var smartFeeEstimates = {};
+
+			//for (var i = 0; i < feeConfTargets.length; i++) {
+			//	var rawSmartFeeEstimate = rawSmartFeeEstimates[i];
+			//	if (rawSmartFeeEstimate.errors) {
+			//		smartFeeEstimates[feeConfTargets[i]] = "?";
+			//	} else {
+			//		smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
+			//	}
+			//}
+
+			res.locals.smartFeeEstimates = smartFeeEstimates;
 
 
-			Promise.all(promises).then(function(promiseResults) {
-				res.locals.mempoolInfo = promiseResults[0];
-				res.locals.miningInfo = promiseResults[1];
+			res.locals.hashrate1d = promiseResults[3];
+			res.locals.hashrate7d = promiseResults[4];
 
-				var rawSmartFeeEstimates = promiseResults[2];
+			res.locals.difficultyPeriodFirstBlockHeader = promiseResults[6];
 
-				var smartFeeEstimates = {};
+			if (data.blockChainInfo.chain !== 'regtest') {
+				res.locals.txStats = promiseResults[7];
 
-				//for (var i = 0; i < feeConfTargets.length; i++) {
-				//	var rawSmartFeeEstimate = rawSmartFeeEstimates[i];
-				//	if (rawSmartFeeEstimate.errors) {
-				//		smartFeeEstimates[feeConfTargets[i]] = "?";
-				//	} else {
-				//		smartFeeEstimates[feeConfTargets[i]] = parseInt(new Decimal(rawSmartFeeEstimate.feerate).times(coinConfig.baseCurrencyUnit.multiplier).dividedBy(1000));
-				//	}
-				//}
-
-				res.locals.smartFeeEstimates = smartFeeEstimates;
-
-
-				res.locals.hashrate1d = promiseResults[3];
-				res.locals.hashrate7d = promiseResults[4];
-
-				var rawblockstats = promiseResults[5];
-				if (rawblockstats && rawblockstats.length > 0 && rawblockstats[0] != null) {
-					res.locals.blockstatsByHeight = {};
-
-					for (var i = 0; i < rawblockstats.length; i++) {
-						var blockstats = rawblockstats[i];
-
-						res.locals.blockstatsByHeight[blockstats.height] = blockstats;
-					}
-				}
-				res.locals.difficultyPeriodFirstBlockHeader = promiseResults[6];
-
-				if (getblockchaininfo.chain !== 'regtest') {
-					res.locals.txStats = promiseResults[7];
-
-					var chainTxStats = [];
-					for (var i = 0; i < res.locals.chainTxStatsLabels.length; i++) {
-						chainTxStats.push(promiseResults[i + 8]);
-					}
-
-					res.locals.chainTxStats = chainTxStats;
+				var chainTxStats = [];
+				for (var i = 0; i < res.locals.chainTxStatsLabels.length; i++) {
+					chainTxStats.push(promiseResults[i + 8]);
 				}
 
-				res.render("index");
-				utils.perfMeasure(req);
-			});
+				res.locals.chainTxStats = chainTxStats;
+			}
+
+			res.render("index");
+			utils.perfMeasure(req);
 		});
 	}).catch(function(err) {
 		res.locals.userMessage = "Error loading recent blocks: " + err;
@@ -346,77 +314,22 @@ router.get("/changeSetting", function(req, res, next) {
 });
 
 router.get("/blocks", function(req, res, next) {
-	var limit = config.site.browseBlocksPageSize;
-	var offset = 0;
-	var sort = "desc";
+	var args = {}
+	if (req.query.limit)
+		args.limit = parseInt(req.query.limit);
+	if (req.query.offset)
+		args.offset = parseInt(req.query.offset);
+	if (req.query.sort)
+		args.sort = req.query.sort;
 
-	if (req.query.limit) {
-		limit = parseInt(req.query.limit);
-	}
-
-	if (req.query.offset) {
-		offset = parseInt(req.query.offset);
-	}
-
-	if (req.query.sort) {
-		sort = req.query.sort;
-	}
-
-	res.locals.limit = limit;
-	res.locals.offset = offset;
-	res.locals.sort = sort;
 	res.locals.paginationBaseUrl = "/blocks";
 
-	coreApi.getBlockchainInfo().then(function(getblockchaininfo) {
-		res.locals.getblockchaininfo = getblockchaininfo;
-		res.locals.blockCount = getblockchaininfo.blocks;
-		res.locals.blockOffset = offset;
+	coreApi.getBlockList(args).then(function(data) {
+		Object.assign(res.locals, data);
 
-		var blockHeights = [];
-		if (sort == "desc") {
-			for (var i = (getblockchaininfo.blocks - offset); i > (getblockchaininfo.blocks - offset - limit - 1); i--) {
-				if (i >= 0) {
-					blockHeights.push(i);
-				}
-			}
-		} else {
-			for (var i = offset - 1; i < (offset + limit); i++) {
-				if (i >= 0) {
-					blockHeights.push(i);
-				}
-			}
-		}
+		res.render("blocks");
 
-		var promises = [];
-
-		promises.push(coreApi.getBlocksByHeight(blockHeights));
-
-		promises.push(coreApi.getBlocksStatsByHeight(blockHeights));
-
-		Promise.all(promises).then(function(promiseResults) {
-			res.locals.blocks = promiseResults[0];
-			var rawblockstats = promiseResults[1];
-
-			if (rawblockstats != null && rawblockstats.length > 0 && rawblockstats[0] != null) {
-				res.locals.blockstatsByHeight = {};
-
-				for (var i = 0; i < rawblockstats.length; i++) {
-					var blockstats = rawblockstats[i];
-
-					res.locals.blockstatsByHeight[blockstats.height] = blockstats;
-				}
-			}
-
-			res.render("blocks");
-			utils.perfMeasure(req);
-
-		}).catch(function(err) {
-			res.locals.pageErrors.push(utils.logError("32974hrbfbvc", err));
-
-			res.render("blocks");
-
-			next();
-		});
+		utils.perfMeasure(req);
 	}).catch(function(err) {
 		res.locals.userMessage = "Error: " + err;
 

--- a/views/blocks.pug
+++ b/views/blocks.pug
@@ -7,30 +7,30 @@ block content
 	h1.h3 Blocks
 	hr
 
-	if (blocks)
+	if (blockList)
 		nav(aria-label="Page navigation")
 			ul.pagination.justify-content-center
 				
-				li.page-item(class=(sort == "desc" ? "active" : false))
-					a.page-link(href=(sort == "desc" ? "javascript:void(0)" : "/blocks?limit=" + limit + "&offset=0" + "&sort=desc"))
+				li.page-item(class=(blockListArgs.sort == "desc" ? "active" : false))
+					a.page-link(href=(blockListArgs.sort == "desc" ? "javascript:void(0)" : "/blocks?limit=" + blockListArgs.limit + "&offset=0" + "&sort=desc"))
 						span(aria-hidden="true") Newest blocks first
 
-				li.page-item(class=(sort == "asc" ? "active" : false))
-					a.page-link(href=(sort == "asc" ? "javascript:void(0)" : "/blocks?limit=" + limit + "&offset=0" + "&sort=asc"))
+				li.page-item(class=(blockListArgs.sort == "asc" ? "active" : false))
+					a.page-link(href=(blockListArgs.sort == "asc" ? "javascript:void(0)" : "/blocks?limit=" + blockListArgs.limit + "&offset=0" + "&sort=asc"))
 						span(aria-hidden="true") Oldest blocks first
 
 		div.card.shadow-sm.mb-3
 			div.card-body
 				include includes/blocks-list.pug
 
-				if (blockCount > limit)
-					- var pageNumber = offset / limit + 1;
-					- var pageCount = Math.floor(blockCount / limit);
-					- if (pageCount * limit < blockCount) {
+				if (blockChainInfo.blocks > blockListArgs.limit)
+					- var pageNumber = blockListArgs.offset / blockListArgs.limit + 1;
+					- var pageCount = Math.floor(blockChainInfo.blocks / blockListArgs.limit);
+					- if (pageCount * blockListArgs.limit < blockChainInfo.blocks) {
 						- pageCount++;
 					- }
 					- var paginationUrlFunction = function(x) {
-						- return paginationBaseUrl + "?limit=" + limit + "&offset=" + ((x - 1) * limit + "&sort=" + sort);
+						- return paginationBaseUrl + "?limit=" + blockListArgs.limit + "&offset=" + ((x - 1) * blockListArgs.limit + "&sort=" + blockListArgs.sort);
 					- }
 					
 					div.pt-5
@@ -40,5 +40,5 @@ block content
 
 
 block endOfBody
-	- var reloadPollUrl = `/api/check-for-new-block/${getblockchaininfo.blocks}`;
+	- var reloadPollUrl = `/api/check-for-new-block/${blockChainInfo.blocks}`;
 		include includes/reload-poll.pug

--- a/views/includes/blocks-list.pug
+++ b/views/includes/blocks-list.pug
@@ -17,7 +17,7 @@ div.table-responsive
 				th.data-header.text-right
 					span.border-dotted(title="The number of transactions included in each block.", data-toggle="tooltip") N(tx)
 
-				if (blockstatsByHeight)
+				if (hasBlockStats)
 					th.data-header.text-right
 						span.border-dotted(title="The total output of all transactions in each block.", data-toggle="tooltip") Volume
 
@@ -30,115 +30,99 @@ div.table-responsive
 
 		tbody
 
-			each block, blockIndex in blocks
-				if (block && ((sort == "desc" && blockIndex < blocks.length - 1) || (sort == "asc" && (block.height == 0 || blockIndex > 0))))
-					tr
-						td
-							if (sort == "desc")
-								small.text-muted #{(blockIndex + offset + 1).toLocaleString()}
-							else
-								small.text-muted #{(blockIndex + offset).toLocaleString()}
-
-						td.data-cell.text-monospace.text-right
-							if (global.specialBlocks && global.specialBlocks[block.hash])
-								a(data-toggle="tooltip", title=(coinConfig.name + " Fun! See block for details"))
-									i.fas.fa-certificate.text-primary.mr-1
-
-							a(href=("/block-height/" + block.height)) #{block.height.toLocaleString()}
-						
-
-						- var timeAgoTime = moment.utc(new Date()).diff(moment.utc(new Date(parseInt(block.time) * 1000)));
-						- var timeAgo = moment.duration(timeAgoTime);
-
-						- var timeDiff = null;
-						
-						if (sort == "asc")
-							if (blockIndex > 0)
-								- var timeDiff = moment.duration(moment.utc(new Date(parseInt(block.time) * 1000)).diff(moment.utc(new Date(parseInt(blocks[blockIndex - 1].time) * 1000))));
+			each block, blockIndex in blockList
+				tr
+					td
+						if (blockListArgs.sort == "desc")
+							small.text-muted #{(blockIndex + blockListArgs.offset + 1).toLocaleString()}
 						else
-							if (blockIndex < blocks.length - 1)
-								- var timeDiff = moment.duration(moment.utc(new Date(parseInt(block.time) * 1000)).diff(moment.utc(new Date(parseInt(blocks[blockIndex + 1].time) * 1000))));
+							small.text-muted #{(blockIndex + blockListArgs.offset).toLocaleString()}
 
-						if (!hideTimestampColumn)
-							td.data-cell.text-monospace.text-right
-								- var timestampHuman = block.time;
-								include timestamp-human.pug
-								
+					td.data-cell.text-monospace.text-right
+						if (global.specialBlocks && global.specialBlocks[block.hash])
+							a(data-toggle="tooltip", title=(coinConfig.name + " Fun! See block for details"))
+								i.fas.fa-certificate.text-primary.mr-1
 
+						a(href=("/block-height/" + block.height)) #{block.height.toLocaleString()}
+					
+
+					- var timeAgoTime = moment.utc(new Date()).diff(moment.utc(new Date(parseInt(block.time) * 1000)));
+					- var timeAgo = moment.duration(timeAgoTime);
+					- var timeDiff = block.timeDiff ? moment.duration(block.timeDiff * 1000) : null;
+					
+					if (!hideTimestampColumn)
 						td.data-cell.text-monospace.text-right
-							if (sort != "asc" && blockIndex == 0 && offset == 0 && timeAgoTime > (15 * 60 * 1000))
-								- var timeAgoTime = block.time;
-								span.text-danger.border-dotted(title="It's been > 15 min since this latest block.", data-toggle="tooltip")
-									include ./time-ago-text.pug
-							else
-								- var timeAgoTime = block.time;
-								include ./time-ago-text.pug
-
-						td.data-cell.text-monospace.text-right
-							if (timeDiff)
-								- var colorClass = "text-muted";
-								if (timeDiff < 300000)
-									- var colorClass = "text-success";
-								if (timeDiff > 900000)
-									- var colorClass = "text-danger";
-
-								span.font-weight-light(class=colorClass)
-									span #{timeDiff.format()}
-
-							else
-								if (block.height == 0)
-									small.border-dotted.text-muted(title="Not applicable: genesis block has no previous block to compare to.", data-toggle="tooltip") N/A (genesis)
-								else
-									span.font-weight-light.text-muted -
-
-						td.data-cell.text-monospace.text-right
-							- var miner = block.miner
-							include coinbase-display.pug
-
-						td.data-cell.text-monospace.text-right #{block.nTx.toLocaleString()}
-
-						if (blockstatsByHeight)
-							td.data-cell.text-monospace.text-right
-								//- console.log(blockstatsByHeight[block.height])
-								if (blockstatsByHeight[block.height])
-									- var currencyValue = parseInt(new Decimal(blockstatsByHeight[block.height].total_out).plus(blockstatsByHeight[block.height].subsidy).plus(blockstatsByHeight[block.height].totalfee));
-									- var currencyValueDecimals = 0;
-									include ./value-display.pug
-
-								else
-									span 0
-
-						td.data-cell.text-monospace.text-right
-							- var currencyValue = new Decimal(block.totalFees).dividedBy(block.size);
-							- var currencyValueDecimals = 2;
-							- currencyFormatTypeOverride = "sat";
-							- currencyUnitSuffix = "/b"
-							include ./value-display.pug
-							- currencyFormatTypeOverride = null
-							- currencyUnitSuffix = null
-
-						td.data-cell.text-monospace.text-right
-							- var currencyValue = new Decimal(block.totalFees).toDecimalPlaces(9);
-							- var currencyValueDecimals = 2;
-							include ./value-display.pug
+							- var timestampHuman = block.time;
+							include timestamp-human.pug
 							
-						
+
+					td.data-cell.text-monospace.text-right
+						if (blockListArgs.sort != "asc" && blockIndex == 0 && blockListArgs.offset == 0 && timeAgoTime > (15 * 60 * 1000))
+							- var timeAgoTime = block.time;
+							span.text-danger.border-dotted(title="It's been > 15 min since this latest block.", data-toggle="tooltip")
+								include ./time-ago-text.pug
+						else
+							- var timeAgoTime = block.time;
+							include ./time-ago-text.pug
+
+					td.data-cell.text-monospace.text-right
+						if (timeDiff)
+							- var colorClass = "text-muted";
+							if (timeDiff < 300000)
+								- var colorClass = "text-success";
+							if (timeDiff > 900000)
+								- var colorClass = "text-danger";
+
+							span.font-weight-light(class=colorClass)
+								span #{timeDiff.format()}
+
+						else
+							if (block.height == 0)
+								small.border-dotted.text-muted(title="Not applicable: genesis block has no previous block to compare to.", data-toggle="tooltip") N/A (genesis)
+							else
+								span.font-weight-light.text-muted -
+
+					td.data-cell.text-monospace.text-right
+						- var miner = block.miner
+						include coinbase-display.pug
+
+					td.data-cell.text-monospace.text-right #{block.nTx.toLocaleString()}
+
+					if (hasBlockStats)
 						td.data-cell.text-monospace.text-right
-							- var data = utils.formatLargeNumber(block.size, 1);
-							- var fullRatio = block.size / coinConfig.maxBlockSizeByNetwork[activeBlockchain];
-							- var full = new Decimal(100 * fullRatio).toDecimalPlaces(1);
-							- var abbr = data[1].abbreviation || "";
-							- var toolTip = `${data[0]} ${abbr}B`;
+							- var currencyValue = new Decimal(block.stats.volume);
+							- var currencyValueDecimals = 0;
+							include ./value-display.pug
 
-								span.border-dotted(title=toolTip, data-toggle="tooltip") #{full}%
-								span  
-								if (full > 90)
-									img(src="/img/block-fullness-3.png", style="width: 18px; height: 18px;")
-								else if (full > 50)
-									img(src="/img/block-fullness-2.png", style="width: 18px; height: 18px;")
-								else if (full > 25)
-									img(src="/img/block-fullness-1.png", style="width: 18px; height: 18px;")
-								else
-									img(src="/img/block-fullness-0.png", style="width: 18px; height: 18px;")
+					td.data-cell.text-monospace.text-right
+						- var currencyValue = new Decimal(block.totalFees).dividedBy(block.size);
+						- var currencyValueDecimals = 2;
+						- currencyFormatTypeOverride = "sat";
+						- currencyUnitSuffix = "/b"
+						include ./value-display.pug
+						- currencyFormatTypeOverride = null
+						- currencyUnitSuffix = null
 
-						- var lastBlock = block;
+					td.data-cell.text-monospace.text-right
+						- var currencyValue = new Decimal(block.totalFees).toDecimalPlaces(9);
+						- var currencyValueDecimals = 2;
+						include ./value-display.pug
+						
+					
+					td.data-cell.text-monospace.text-right
+						- var data = utils.formatLargeNumber(block.size, 1);
+						- var fullRatio = block.size / coinConfig.maxBlockSizeByNetwork[activeBlockchain];
+						- var full = new Decimal(100 * fullRatio).toDecimalPlaces(1);
+						- var abbr = data[1].abbreviation || "";
+						- var toolTip = `${data[0]} ${abbr}B`;
+
+							span.border-dotted(title=toolTip, data-toggle="tooltip") #{full}%
+							span  
+							if (full > 90)
+								img(src="/img/block-fullness-3.png", style="width: 18px; height: 18px;")
+							else if (full > 50)
+								img(src="/img/block-fullness-2.png", style="width: 18px; height: 18px;")
+							else if (full > 25)
+								img(src="/img/block-fullness-1.png", style="width: 18px; height: 18px;")
+							else
+								img(src="/img/block-fullness-0.png", style="width: 18px; height: 18px;")

--- a/views/includes/index-network-summary.pug
+++ b/views/includes/index-network-summary.pug
@@ -32,7 +32,7 @@ div.row.index-summary
 						i.fas.fa-edit.mr-1.summary-icon
 						span.border-dotted(title="Estimate of the number of days the current BCH hashrate would require to produce all the hashes needed to re-write the entire blockchain.", data-toggle="tooltip") Chain Rewrite Days
 					td.text-right.text-monospace
-						- var globalHashCount = parseInt("0x" + getblockchaininfo.chainwork);
+						- var globalHashCount = parseInt("0x" + blockChainInfo.chainwork);
 						- var rewriteDays = globalHashCount / hashrate7d / 60 / 60 / 24;
 						span #{new Decimal(rewriteDays).toDecimalPlaces(1)}
 
@@ -41,8 +41,8 @@ div.row.index-summary
 						i.fas.fa-dumbbell.mr-1.summary-icon
 						span Difficulty
 					td.text-right.text-monospace
-						- var difficultyData = utils.formatLargeNumber(getblockchaininfo.difficulty, 2);
-						span.border-dotted(data-toggle="tooltip", title=parseFloat(getblockchaininfo.difficulty).toLocaleString())
+						- var difficultyData = utils.formatLargeNumber(blockChainInfo.difficulty, 2);
+						span.border-dotted(data-toggle="tooltip", title=parseFloat(blockChainInfo.difficulty).toLocaleString())
 							span #{difficultyData[0]}
 							small.px-2.px-lg-0.px-xl-2 x
 							span 10
@@ -77,8 +77,8 @@ div.row.index-summary
 						else
 							span ???
 
-				if (getblockchaininfo.size_on_disk)
-					- var sizeData = utils.formatLargeNumber(getblockchaininfo.size_on_disk, 2);
+				if (blockChainInfo.size_on_disk)
+					- var sizeData = utils.formatLargeNumber(blockChainInfo.size_on_disk, 2);
 
 					tr
 						th.px-2.px-lg-0.px-xl-2
@@ -91,8 +91,8 @@ div.row.index-summary
 						i.fas.fa-bolt.mr-1.summary-icon
 						span.border-dotted(title="The total amount of work necessary to produce the active chain, approximated in 'hashes'.", data-toggle="tooltip") Chain Work
 					td.text-right.text-monospace
-						- var chainworkData = utils.formatLargeNumber(parseInt("0x" + getblockchaininfo.chainwork), 2);
-						span.border-dotted(data-toggle="tooltip", title=`hex: ${getblockchaininfo.chainwork.replace(/^0+/, '')}`)
+						- var chainworkData = utils.formatLargeNumber(parseInt("0x" + blockChainInfo.chainwork), 2);
+						span.border-dotted(data-toggle="tooltip", title=`hex: ${blockChainInfo.chainwork.replace(/^0+/, '')}`)
 							span #{chainworkData[0]}
 							small.px-2.px-lg-0.px-xl-2 x
 							span 10

--- a/views/index.pug
+++ b/views/index.pug
@@ -4,7 +4,7 @@ block headContent
 	+title('Home')
 	
 block content
-	if (getblockchaininfo == null)
+	if (blockChainInfo == null)
 		div.alert.alert-warning
 			p.font-weight-bold Unable to get basic blockchain data
 			ul
@@ -44,14 +44,14 @@ block content
 				a.close(href="/changeSetting?name=hideHomepageBanner&value=true", aria-label="Close", style="text-decoration: none;")
 					span(aria-hidden="true") &times;
 
-		if (getblockchaininfo.initialblockdownload)
+		if (blockChainInfo.initialblockdownload)
 			div.alert.alert-warning.shadow-sm.border.mb-3
 				div.font-weight-bold.mb-1 Initial Block Download (IBD) - In Progress...
 
 				div.mb-1 Your node is currently downloading and verifying blockchain data. Until the process is finished, some features of this tool will be unusable and/or unreliable.
 
 				span.font-weight-bold Progress: 
-				span.text-monospace #{new Decimal(getblockchaininfo.verificationprogress).times(100).toDP(3)}%
+				span.text-monospace #{new Decimal(blockChainInfo.verificationprogress).times(100).toDP(3)}%
 
 
 		div.row
@@ -81,24 +81,22 @@ block content
 						include includes/tools-card.pug
 		
 		
-		if (latestBlocks)
-			div.row.mb-3
-				div.col
-					div.card.shadow-sm
-						div.card-body.px-2.px-sm-3
-							div.row
-								div.col
-									h3.h6.mb-0 Latest Blocks
-									
-								div.col.text-right
-									a(href="/blocks") See more &raquo;
+		div.row.mb-3
+			div.col
+				div.card.shadow-sm
+					div.card-body.px-2.px-sm-3
+						div.row
+							div.col
+								h3.h6.mb-0 Latest Blocks
+								
+							div.col.text-right
+								a(href="/blocks") See more &raquo;
 
-							hr
+						hr
 
-							- var blocks = latestBlocks;
-							- var blockOffset = 0;
+						- var blockOffset = 0;
 
-							include includes/blocks-list.pug
+						include includes/blocks-list.pug
 
 		if (txStats)
 			div.row.mb-3
@@ -143,5 +141,5 @@ block content
 
 
 block endOfBody
-	- var reloadPollUrl = `/api/check-for-new-block/${getblockchaininfo.blocks}`;
+	- var reloadPollUrl = `/api/check-for-new-block/${blockChainInfo.blocks}`;
 		include includes/reload-poll.pug


### PR DESCRIPTION
This makes the `/` and `/blocks` endpoints use the new common `getBlockList` function, reducing code duplication. The data is alos exposed through the `/blocks` API endpoint.