### PR TITLE
Use USD as default currency when currency unit is set to f(BCH)

### DIFF
--- a/views/includes/index-network-summary.pug
+++ b/views/includes/index-network-summary.pug
@@ -184,11 +184,11 @@ div.row.index-summary
 								td.text-right.text-monospace
 									if (utxoSetSummary)
 										- var activeCurrency = global.currencyFormatType.length > 0 ? global.currencyFormatType : "usd";
-										- var xxx = utils.formatLargeNumber(parseFloat(utxoSetSummary.total_amount) * exchangeRates[activeCurrency], 1);
-
 										if (activeCurrency == "eur")
+											- var xxx = utils.formatLargeNumber(parseFloat(utxoSetSummary.total_amount) * exchangeRates[activeCurrency], 1);
 											span €
 										else
+											- var xxx = utils.formatLargeNumber(parseFloat(utxoSetSummary.total_amount) * exchangeRates["usd"], 1);
 											span $
 
 										span #{xxx[0]}


### PR DESCRIPTION
This is needed eg when computing the Market Cap value. If someone
set BCH of "bits" as currency unit we need to fall back to a default
fiat currency to compute market cap value in fiat terms.