### PR TITLE
fix tx decoder case where there are no inputs

### DIFF
--- a/views/decoder.pug
+++ b/views/decoder.pug
@@ -28,7 +28,7 @@ block content
 			if type === "script"
 				div.mb-5 !{decodedDetails}
 			else if type === "tx"
-				if (tx.vin[0].coinbase)
+				if (tx.vin.length > 0 && tx.vin[0].coinbase)
 					div.card.shadow-sm.mb-3
 						div.card-body.px-2.px-md-3
 							h2.h6.mb-0 Coinbase


### PR DESCRIPTION
Although a tx with no inputs is invalid, they are commonly created as an interim step to producing a full transaction, so decoding them is useful.
 
test case: 01000000000100ca9a3b000000001976a914204104566974460fa7130759fdcec05e4c26e74888ac00000000
