### PR TITLE
Skip undefined flags in address details

### DIFF
--- a/views/address.pug
+++ b/views/address.pug
@@ -180,6 +180,8 @@ block content
 									- var flags = [x.isvalid, x.isscript, x.ismine, x.iswatchonly];
 
 									each flagName, index in flagNames
+										if flags[index] === undefined
+											- continue
 										div.row
 											div.summary-split-table-label #{flagName}
 											div.summary-split-table-content.text-monospace


### PR DESCRIPTION
"Is Mine" and "Is watch-only" only make sense when running the block explorer connected to a wallet. If there is no wallet, the property is undefined and we should skip it in that case.

closes #147