### PR TITLE
Extends exchange rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ The below instructions are geared toward BCH, but can be adapted easily to other
 
 ## Prerequisites
 
-1. Install and run a full, archiving node - [instructions](https://bitcoinunlimited.info/download). Ensure that your bitcoin node has full transaction indexing enabled (`txindex=1`) and the RPC server enabled (`server=1`).
+1. Install and run a full, archiving node - [instructions](https://bitcoinunlimited.info/download). Ensure that your bitcoin node has full transaction indexing enabled (`txindex=1`) and the RPC server enabled (`server=1`) adding the flags into the bitcoind executable.
 2. Synchronize your node with the Bitcoin network.
+3. Run bch-rpc-explorer passing the cookie route based on the defined path to store files download with BCH-Unlimited. (Check cli arguments section)
 3. "Recent" version of Node.js (8+ recommended).
-4. You could also run an [ElectrsCash](https://github.com/bitcoinunlimited/ElectrsCash) and configure the explorer to received data from it
+4. You could also run an [ElectrsCash](https://github.com/bitcoinunlimited/ElectrsCash) and configure the explorer to received data from it (optional)
 5. You need to use nodejs version 12.9 or higher due to the use of [Promise.allSettled()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method
 
 ## Instructions
@@ -61,7 +62,11 @@ See [.env-sample](.env-sample) for a list of the options and details for formatt
 You may also pass options as CLI arguments, for example:
 
 ```bash
+UNIX
 bch-rpc-explorer --port 8080 --bitcoind-port 18443 --bitcoind-cookie ~/.bitcoin/regtest/.cookie
+
+WINDOWS
+bch-rpc-explorer --bitcoind-cookie C:\your-bch-unlimited-path\.cookie
 ```
 
 See `bch-rpc-explorer --help` for the full list of CLI options.

--- a/app/coins/bch.js
+++ b/app/coins/bch.js
@@ -47,6 +47,14 @@ var currencyUnits = [
 		decimalPlaces:2,
 		symbol:"€"
 	},
+	{
+		type:"exchanged",
+		name:"ARS",
+		multiplier:"ars",
+		values:["ars"],
+		decimalPlaces:2,
+		symbol:"$",
+	},
 ];
 
 module.exports = {
@@ -600,7 +608,34 @@ module.exports = {
 			return null;
 		}
 	},
+	exchangedRateDataExtension:[
+		{
+			jsonUrl:"https://api.yadio.io/exrates",
+			responseBodySelectorFunction:function(responseBody) {
+				//console.log("Exchange Rate Response: " + JSON.stringify(responseBody));
 
+				var exchangedCurrencies = ["ARS"];
+				
+				if (responseBody.base) {
+					var exchangeRates = {};
+					
+					for (var i = 0; i < exchangedCurrencies.length; i++) {
+						var key = exchangedCurrencies[i];
+						if (responseBody['USD']) {
+							// If found duped currency units for the same api source then skip all instead of retrieve wrong rates.
+							var applicableUnit = currencyUnits.filter(x => x.name === key).length == 1 ? currencyUnits.find(x => x.name === key) : undefined;
+							if (applicableUnit) {
+								exchangeRates[key.toLowerCase()] = parseFloat(responseBody['USD'][key]).toString();
+							}
+						}
+					}
+					return exchangeRates;
+				}
+	
+				return null;
+			}
+		}
+	],
 	blockRewardFunction:function(blockHeight, chain) {
 		var eras = [ new Decimal8(50) ];
 		for (var i = 1; i < 34; i++) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "gypfile": true,
   "scripts": {
     "start": "node ./bin/www",
-    "refresh-mining-pool-configs": "node ./bin/refresh-mining-pool-configs.js"
+    "refresh-mining-pool-configs": "node ./bin/refresh-mining-pool-configs.js",
+    "start-cli": "node ./bin/cli.js"
   },
   "keywords": [
     "bitcoin cash",

--- a/views/includes/value-display.pug
+++ b/views/includes/value-display.pug
@@ -27,3 +27,5 @@ if (currencyValue > 0)
 
 else
 	span.text-monospace 0
+br
+small #{utils.getExchangeRatesUpdateTime()}


### PR DESCRIPTION
# Extends exchange rates with more APIs than Kracken

## **What?:**
Adds a new Exchange Rate for Argentinian pounds (ARS).
Adds local time in the amount value display.

## **Why?:**
-Kracken doesn't include rate conversion for most countries from South America, Argentina for instance.
-It is more customizable to use a simple rate conversion from local currency to USD and then based on the BCHUSD exchange calculate the final exchange rate.
-In many 3rd world countries users checks continuously the time of the exchange rate

## **Where?:**
-These changes affect the value-display general component to show the last refresh local time of the exchange rate.
-These changes only apply when the --no-rates option is disabled

## **How looks?:**
![image](https://user-images.githubusercontent.com/7245667/137622351-ce854ce7-e0cc-49f0-8ceb-a8668bbecb62.png)
![image](https://user-images.githubusercontent.com/7245667/137622341-af73e5b1-aeab-4d14-89de-a46c40b9645e.png)
![image](https://user-images.githubusercontent.com/7245667/137622372-051685fb-74c6-4249-a85a-6dfbc8f5bf2a.png)



