### PR TITLE
Adds the transaction arrival time in the local timezone

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -822,6 +822,14 @@ function serviceBitsToName (services) {
 	return serviceBits;
 }
 
+function getTransactionDatetime(utcEpochTime) {
+	var epoch = new Date(0);
+	epoch.setUTCSeconds(utcEpochTime);
+	var formatted_date = epoch.getFullYear() + "-" + (epoch.getMonth() + 1) + "-" + epoch.getDate() + " " + epoch.toLocaleTimeString();
+
+	return formatted_date;
+}
+
 module.exports = {
 	reflectPromise: reflectPromise,
 	redirectToConnectPageIfNeeded: redirectToConnectPageIfNeeded,
@@ -861,5 +869,6 @@ module.exports = {
 	outputTypeAbbreviation: outputTypeAbbreviation,
 	outputTypeName: outputTypeName,
 	serviceBitsToName: serviceBitsToName,
-	perfMeasure: perfMeasure
+	perfMeasure: perfMeasure,
+	getTransactionDatetime: getTransactionDatetime
 };

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -386,6 +386,7 @@ div.tab-content
 									span(title=`Index in Block: #${(txIndex + offset).toLocaleString()}`, data-toggle="tooltip") ##{(txIndex + offset).toLocaleString()}
 									span  &ndash; 
 									a(href=("/tx/" + tx.txid)) #{tx.txid}
+									span  &ndash; Transaction arrived at: #{utils.getTransactionDatetime(tx.time)} (local time)
 
 									if (global.specialTransactions && global.specialTransactions[tx.txid])
 										span  


### PR DESCRIPTION
# Local time of transactions arrival

## **What?:**
Adds local time of the transactions

## **Why?:**
-In many 3rd world countries users checks continuously the time of the transaction

## **Where?:**
-This affects the block-content component to show the local time of the transaction arrival

## **How looks?:**
![image](https://user-images.githubusercontent.com/7245667/137838771-e52d7412-db80-4e66-b723-ad32c7958187.png)