### PR TITLE
Fixing issue with local timezone, removing local time for now

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -860,7 +860,7 @@ function serviceBitsToName (services) {
 function getTransactionDatetime(utcEpochTime) {
 	var epoch = new Date(0);
 	epoch.setUTCSeconds(utcEpochTime);
-	var formatted_date = epoch.getFullYear() + "-" + (epoch.getMonth() + 1) + "-" + epoch.getDate() + " " + epoch.toLocaleTimeString();
+	var formatted_date = epoch.getFullYear() + "-" + (epoch.getMonth() + 1) + "-" + epoch.getDate() + " " + epoch.toUTCString();
 
 	return formatted_date;
 }

--- a/views/includes/block-content.pug
+++ b/views/includes/block-content.pug
@@ -386,7 +386,7 @@ div.tab-content
 									span(title=`Index in Block: #${(txIndex + offset).toLocaleString()}`, data-toggle="tooltip") ##{(txIndex + offset).toLocaleString()}
 									span  &ndash; 
 									a(href=("/tx/" + tx.txid)) #{tx.txid}
-									span  &ndash; Transaction arrived at: #{utils.getTransactionDatetime(tx.time)} (local time)
+									span  &ndash; Transaction arrived at: #{utils.getTransactionDatetime(tx.time)} (UTC time)
 
 									if (global.specialTransactions && global.specialTransactions[tx.txid])
 										span  


### PR DESCRIPTION
# Local time of transactions arrival in UTC
## What?:
-The local time conversion seems to be working as not expected way, for some reason the local time conversion function from js is not working correctly on the client-side (frontend)

## Why?:
-The converted DateTime seems to be different than the correct one for some reason

## Where?:
-This affects the block-content component to show the local time of the transaction arrival

## How looks the issue?:
In production:
![image](https://user-images.githubusercontent.com/7245667/138269249-fe89c5ce-7967-462a-b19a-03bb42161e8b.png)
In local environment:
![image](https://user-images.githubusercontent.com/7245667/138269213-339320a9-7265-45c4-841a-0668d55da5c8.png)
Client time:
![image](https://user-images.githubusercontent.com/7245667/138269774-d6718614-6b73-4b71-82a5-90dd762c0021.png)

## Workaround:
Shows UTC instead local time
