### PR TITLE
Fix error handling when rendering a non existent transaction

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -955,6 +955,10 @@ router.get("/tx/:transactionId", function(req, res, next) {
 				coreApi.getBlockHeader(tx.blockhash).then(function(blockHeader) {
 					res.locals.result.blockHeader = blockHeader;
 					resolve()
+				}).catch(function(err) {
+					res.locals.pageErrors.push(utils.logError("1234abc456efd", err));
+
+					reject(err);
 				});
 			}));
 		}
@@ -963,13 +967,12 @@ router.get("/tx/:transactionId", function(req, res, next) {
 			res.render("transaction");
 			utils.perfMeasure(req);
 
-
+		}).catch(function(err) {
+			res.locals.userMessageMarkdown = `Failed to load transaction: txid=**${txid}**`;
+			res.render("transacition");
 		});
-
 	}).catch(function(err) {
 		res.locals.userMessageMarkdown = `Failed to load transaction: txid=**${txid}**`;
-
-	}).catch(function(err) {
 		res.locals.pageErrors.push(utils.logError("1237y4ewssgt", err));
 
 		res.render("transaction");


### PR DESCRIPTION
If someone try to use the 'tx/:transactionId' endpoint using
a non existent ID we are now properly handling the error, before
the error was uncaught and the request timed out.