### PR TITLE
Add AS from getpeerinfo mapped_as to the peers views

### DIFF
--- a/app/api/coreApi.js
+++ b/app/api/coreApi.js
@@ -353,6 +353,8 @@ function getPeerSummary() {
 			var result = {};
 			result.getpeerinfo = getpeerinfo;
 
+			result.getpeerinfo_has_mapped_as = getpeerinfo.length > 0 && "mapped_as" in getpeerinfo[0];
+
 			var versionSummaryMap = {};
 			for (var i = 0; i < getpeerinfo.length; i++) {
 				var x = getpeerinfo[i];

--- a/views/peers.pug
+++ b/views/peers.pug
@@ -101,6 +101,9 @@ block content
 
 								if (peerIpSummary && peerIpSummary.ips)
 									th.data-header Location
+								
+								if (peerSummary.getpeerinfo_has_mapped_as)
+									th.data-header AS
 
 								th.data-header Last Send / Receive (m:s)
 
@@ -132,6 +135,10 @@ block content
 												span ?
 
 											- var ipAddr = null;
+
+									if (peerSummary.getpeerinfo_has_mapped_as)
+										td.data-cell.text-monospace
+											a(href="https://bgp.he.net/AS" + item.mapped_as) AS#{item.mapped_as}
 
 									td.ata-cell.text-monospace #{lastSendAgo} / #{lastRecvAgo}
 


### PR DESCRIPTION
Checks if the getpeerinfo contains the mapped_as attribute and outputs the AS only if it exists.