### PR TITLE
Use possibleSignal as an alternative way to identify a miner

### DIFF
--- a/app/utils.js
+++ b/app/utils.js
@@ -417,6 +417,9 @@ function getMinerFromCoinbaseTx(tx) {
 			}
 		}
 	}
+	if ((!minerInfo.indentiedBy) && (minerInfo.possibleSignal)) {
+		minerInfo.name = minerInfo.possibleSignal;
+	}
 	return minerInfo;
 }
 


### PR DESCRIPTION
In case there's not enough info in our miners lists to identify the miner of a given block, use possibleSignal to categorize the block