### PR TITLE
Fix get_balance

### DIFF
--- a/app/api/electrumAddressApi.js
+++ b/app/api/electrumAddressApi.js
@@ -46,7 +46,7 @@ function connectToServer(host, port, protocol) {
 		// default protocol is 'tcp' if port is 50001, which is the default unencrypted port for electrumx
 		var defaultProtocol = port === 50001 ? 'tcp' : 'tls';
 
-		var electrumConfig = { client:"bch-rpc-explorer", version:"1.4" };
+		var electrumConfig = { client:"bch-rpc-explorer", version:["1.4", "1.5"] };
 		var electrumPersistencePolicy = { retryPeriod: 10000, maxRetry: 1000, callback: null };
 
 		var onConnect = function(client, versionInfo) {


### PR DESCRIPTION
Rostrum 9.0.0 and Fulcrum 1.9.X introduced a modification to blockchain.address.get_balance.

The change is related to the activation of CashTokens on May 2023

An optional parameter has been added to get_balance, namely token_filter, so that in the calculated amount UTXOs associated to an address could be counted in or not on the base of their association to a toke.

That lead to some kind of weird corner case where not all UTXOs got considered while computing the amount of a given address.

The fix comes down to negotiate the proper protocol version between the explorer and the electrum server. In case of Rostrum 1.4 is the max proto version and the one that is needed to get a balance accounting for all UTXOs. For Fulcrum 1.9.x 1.5 is the right proto version (prior to that the get_balance is supposed to accept only 1 parameter).

Should fix #190 