### PR TITLE
Add a temporary rate limit to /address views

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dotenv": "^8.2.0",
     "electrum-client": "github:janoside/electrum-client",
     "express": "^4.17.1",
+    "express-rate-limit": "^6.6.0",
     "express-session": "^1.17.1",
     "jstransformer-markdown-it": "^2.1.0",
     "lru-cache": "^5.1.1",

--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -2,6 +2,7 @@ var debug = require("debug");
 var debugLog = debug("bchexp:router");
 
 var express = require('express');
+const rateLimit = require('express-rate-limit');
 var csurf = require('csurf');
 var router = express.Router();
 var util = require('util');
@@ -979,7 +980,15 @@ router.get("/tx/:transactionId", function(req, res, next) {
 	});
 });
 
-router.get("/address/:address", async (req, res) => {
+const addressLimiter = rateLimit({
+	       windowMs: 1 * 60 * 1000,
+	       max: 1,
+	       standardHeaders: true,
+	       legacyHeaders: false,
+});
+
+
+router.get("/address/:address", addressLimiter, async (req, res) => {
 	var limit = config.site.addressTxPageSize;
 	var offset = 0;
 	var sort = "desc";


### PR DESCRIPTION
That view rendering could pretty resource consuming when the address we are looking for has a very long transaction history.

I'm going to temporarely add a rate limit for that view that take into account the number of requests for a given time interval by the same IP address.

Once pagination would be provided by Eletrum servers (eg Rostrum) for the used methods (eg get_history)  we could use it to reduce the amount of load anda data involved and we will be able to remove the rate limit on the page.